### PR TITLE
Remove organization from the initial form data and from validation

### DIFF
--- a/mscr-ui/src/common/utils/hooks/use-initial-schema-form.tsx
+++ b/mscr-ui/src/common/utils/hooks/use-initial-schema-form.tsx
@@ -35,12 +35,7 @@ export function useInitialSchemaForm(): SchemaFormType {
         selected: false,
       },
     ],
-    organizations: [
-      {
-        uniqueItemId: '7d3a3c00-5a6b-489b-a3ed-63bb58c26a63',
-        labelText: 'Interoperabilty Platform',
-      },
-    ],
+    organizations: [],
     filedata: '',
     serviceCategories: '',
     contact: true,

--- a/mscr-ui/src/modules/schema-form/validate-form.tsx
+++ b/mscr-ui/src/modules/schema-form/validate-form.tsx
@@ -6,7 +6,6 @@ export interface FormErrors {
   titleAmount: string[];
   prefix: boolean;
   serviceCategories: boolean;
-  organizations: boolean;
   fileData: boolean;
 }
 
@@ -20,7 +19,6 @@ export function validateForm(
     titleAmount: [],
     prefix: false,
     serviceCategories: false,
-    organizations: false,
     fileData: false,
   };
 
@@ -48,11 +46,6 @@ export function validateForm(
       .map((lang: { uniqueItemId: any }) => lang.uniqueItemId);
 
     errors.titleAmount = langsWithError ?? [];
-  }
-
-  // Should have at least one organization set
-  if (data.organizations.length < 1) {
-    errors.organizations = true;
   }
 
   if (!fileData) {


### PR DESCRIPTION
Since the backend was updated to not require an organization when registering content, the requirement is here removed from the front end as well. Now content can be registered as personal.