### PR TITLE
CSCFC4EMSCR-277 Invalid url gives 404

### DIFF
--- a/mscr-ui/next.config.js
+++ b/mscr-ui/next.config.js
@@ -91,6 +91,17 @@ module.exports = () => {
           destination: '/personal/content',
           permanent: false,
         },
+        {
+          source: '/401',
+          has: [
+            {
+              type: 'cookie',
+              key: 'user-session-cookie',
+            },
+          ],
+          destination: '/',
+          permanent: false,
+        },
       ];
     },
   };

--- a/mscr-ui/public/locales/en/common.json
+++ b/mscr-ui/public/locales/en/common.json
@@ -190,6 +190,7 @@
   "site-logout": "Log out",
   "site-open-link-new-window": "",
   "site-open-new-email": "",
+  "site-page-not-found": "Content not available, check url",
   "site-register": "",
   "site-services": "",
   "site-title": "Metadata Schema and Crosswalk Regisrtry",

--- a/mscr-ui/public/locales/fi/common.json
+++ b/mscr-ui/public/locales/fi/common.json
@@ -190,6 +190,7 @@
   "site-logout": "",
   "site-open-link-new-window": "",
   "site-open-new-email": "",
+  "site-page-not-found": "",
   "site-register": "",
   "site-services": "",
   "site-title": "",

--- a/mscr-ui/public/locales/sv/common.json
+++ b/mscr-ui/public/locales/sv/common.json
@@ -190,6 +190,7 @@
   "site-logout": "logout",
   "site-open-link-new-window": "",
   "site-open-new-email": "",
+  "site-page-not-found": "",
   "site-register": "",
   "site-services": "",
   "site-title": "",

--- a/mscr-ui/src/common/components/smart-header/index.tsx
+++ b/mscr-ui/src/common/components/smart-header/index.tsx
@@ -48,7 +48,7 @@ export default function SmartHeader({
     setIsExpanded(false);
   };
 
-  if (user?.anonymous && router.asPath == '/') {
+  if (user?.anonymous && (router.asPath == '/' || router.asPath == '/401')) {
     return <>{renderLandingHeader()}</>;
   }
 

--- a/mscr-ui/src/pages/401/index.tsx
+++ b/mscr-ui/src/pages/401/index.tsx
@@ -1,0 +1,33 @@
+import { CommonContextProvider, CommonContextState } from 'yti-common-ui/components/common-context-provider';
+import { SSRConfig, useTranslation } from 'next-i18next';
+import PageHead from 'yti-common-ui/components/page-head';
+import Layout from '@app/common/components/layout';
+import { MscrUser } from '@app/common/interfaces/mscr-user.interface';
+import { createCommonGetServerSideProps } from '@app/common/utils/create-getserversideprops';
+
+interface unauthorizedPageProps extends CommonContextState {
+  _netI18Next: SSRConfig;
+  user: MscrUser;
+}
+export default function UnauthorizedPage(props: unauthorizedPageProps) {
+  const { t } = useTranslation('common');
+
+  return (
+    <CommonContextProvider value={props}>
+      <Layout
+        user={props.user ?? undefined}
+        fakeableUsers={props.fakeableUsers}
+      >
+        <PageHead
+          baseUrl="https://mscr-test.rahtiapp.fi"
+          title={t('mscr-title')}
+          description={t('service-description')}
+        />
+        <p>You need to be logged in to view this content</p>
+      </Layout>
+
+    </CommonContextProvider>
+  );
+}
+
+export const getServerSideProps = createCommonGetServerSideProps();

--- a/mscr-ui/src/pages/401/index.tsx
+++ b/mscr-ui/src/pages/401/index.tsx
@@ -1,4 +1,7 @@
-import { CommonContextProvider, CommonContextState } from 'yti-common-ui/components/common-context-provider';
+import {
+  CommonContextProvider,
+  CommonContextState,
+} from 'yti-common-ui/components/common-context-provider';
 import { SSRConfig, useTranslation } from 'next-i18next';
 import PageHead from 'yti-common-ui/components/page-head';
 import Layout from '@app/common/components/layout';
@@ -25,7 +28,6 @@ export default function UnauthorizedPage(props: unauthorizedPageProps) {
         />
         <p>You need to be logged in to view this content</p>
       </Layout>
-
     </CommonContextProvider>
   );
 }

--- a/mscr-ui/src/pages/[homepage]/content/index.tsx
+++ b/mscr-ui/src/pages/[homepage]/content/index.tsx
@@ -34,6 +34,11 @@ export default function IndexPage(props: IndexPageProps) {
   const { t } = useTranslation('common');
   const router = useRouter();
 
+  // TODO: Implement a util function somewhere to validate pids
+  // TODO: Check user is authenticated to see that group
+  function isValidPid(type: string, pid: string | undefined) {
+    return false;
+  }
   function DisplayedComponent({
     slug,
     user,
@@ -43,8 +48,11 @@ export default function IndexPage(props: IndexPageProps) {
   }): React.ReactElement {
     if (slug === 'personal') {
       return <PersonalWorkspace pid={''} user={user} />;
-    } else {
+    } else if (isValidPid('group', slug)) {
       return <GroupWorkspace pid={slug ?? ''} user={user} />;
+    } else {
+      // TODO: Implement some kind of 'Oops, can't find that page' view
+      return <p>{t('site-page-not-found')}</p>;
     }
   }
 

--- a/mscr-ui/src/pages/[homepage]/content/index.tsx
+++ b/mscr-ui/src/pages/[homepage]/content/index.tsx
@@ -131,6 +131,10 @@ export const getServerSideProps = createCommonGetServerSideProps(
     await Promise.all(store.dispatch(getOrganizationsRunningQueriesThunk()));
     await Promise.all(store.dispatch(getCountRunningQueriesThunk()));
 
-    return {};
+    return {
+      props: {
+        requireAuthenticated: true,
+      },
+    };
   }
 );

--- a/mscr-ui/src/pages/[homepage]/deprecated-index.tsx
+++ b/mscr-ui/src/pages/[homepage]/deprecated-index.tsx
@@ -5,7 +5,6 @@ import {
 import Layout from '@app/common/components/layout';
 import { SSRConfig, useTranslation } from 'next-i18next';
 import { createCommonGetServerSideProps } from '@app/common/utils/create-getserversideprops';
-import FrontPage from '@app/modules/front-page';
 import {
   getOrganizations,
   getRunningQueriesThunk as getOrganizationsRunningQueriesThunk,
@@ -22,13 +21,10 @@ import {
 } from '@app/common/components/counts/counts.slice';
 
 import { useRouter } from 'next/router';
-import { User } from 'yti-common-ui/interfaces/user.interface';
 import GroupWorkspace from '../../modules/group-home';
 import PersonalWorkspace from '../../modules/personal-home';
 import { useBreakpoints } from 'yti-common-ui/media-query';
 
-import { Grid } from '@mui/material';
-import SideNavigationPanel from '@app/common/components/side-navigation';
 import CrosswalkEditor from '@app/modules/crosswalk-editor';
 import { MscrUser } from '@app/common/interfaces/mscr-user.interface';
 
@@ -39,9 +35,7 @@ interface IndexPageProps extends CommonContextState {
 
 export default function IndexPage(props: IndexPageProps) {
   const { t } = useTranslation('common');
-
   const router = useRouter();
-
   const { breakpoint } = useBreakpoints();
 
   function DisplayedComponent({
@@ -56,7 +50,7 @@ export default function IndexPage(props: IndexPageProps) {
     } else if (slug === 'crosswalk-edit') {
       return <CrosswalkEditor />;
     } else {
-      console.log(slug);
+      // console.log(slug);
       return <PersonalWorkspace pid={''} user={user} />;
     }
   }

--- a/mscr-ui/src/pages/[homepage]/settings/mock-index.tsx
+++ b/mscr-ui/src/pages/[homepage]/settings/mock-index.tsx
@@ -2,7 +2,7 @@ import {
   CommonContextProvider,
   CommonContextState,
 } from 'yti-common-ui/components/common-context-provider';
-import { SSRConfig, useTranslation } from 'next-i18next';
+import { SSRConfig } from 'next-i18next';
 import Layout from '@app/common/components/layout';
 import PageHead from 'yti-common-ui/components/page-head';
 import PersonalSettings from 'src/modules/personal-settings';
@@ -25,8 +25,7 @@ function SettingsByType(settingsType: string): React.ReactElement {
 
 // This is just a mock page. I do not yet understand the proper construction of a page. Replace with real page.
 export default function IndexPage(props: IndexPageProps) {
-  const { t } = useTranslation('common');
-  console.log('settings type: ', props.settingsType);
+  // console.log('settings type: ', props.settingsType);
   return (
     <CommonContextProvider value={props}>
       <Layout
@@ -34,7 +33,7 @@ export default function IndexPage(props: IndexPageProps) {
         fakeableUsers={props.fakeableUsers}
       >
         <PageHead
-          baseUrl="https://tietomallit.suomi.fi"
+          baseUrl="https://mscr-test.rahtiapp.fi/"
           title="Settings testisivu"
           description="Only for testing"
         />
@@ -53,7 +52,6 @@ export const getServerSideProps = createCommonGetServerSideProps(
     if (settingsType === undefined) {
       throw new Error('Invalid parameter for page');
     }
-    console.log(settingsType);
 
     return {
       props: {

--- a/mscr-ui/src/pages/index.tsx
+++ b/mscr-ui/src/pages/index.tsx
@@ -41,8 +41,7 @@ export default function IndexPage(props: IndexPageProps) {
         fakeableUsers={props.fakeableUsers}
       >
         <PageHead
-          // TODO: Change baseUrl
-          baseUrl="https://localhost:3000"
+          baseUrl="https://mscr-test.rahtiapp.fi"
           title={t('mscr-title')}
           description={t('service-description')}
         />


### PR DESCRIPTION
Redirecting was a bit too tricky, I didn't quite get the hang of it. So I just removed the /[homepage]/index from navigation by renaming it deprecated-index.tsx, since it gives access that a user shouldn't be accessing. You can rename it index.tsx for temporary use in development, if needed.
Accessing /personal/content now requires logging in.