### PR TITLE
Remove redirecting from 401 page to landing

### DIFF
--- a/mscr-ui/next.config.js
+++ b/mscr-ui/next.config.js
@@ -91,17 +91,6 @@ module.exports = () => {
           destination: '/personal/content',
           permanent: false,
         },
-        {
-          source: '/401',
-          has: [
-            {
-              type: 'cookie',
-              key: 'user-session-cookie',
-            },
-          ],
-          destination: '/',
-          permanent: false,
-        },
       ];
     },
   };


### PR DESCRIPTION
Seems that sometimes the user-session-cookie vs requireAuthenticated in personal/content is a bit unclear, and then redirection gets circular. Not sure if this can happen on rahti.