### PR TITLE
MSCR-293 Fix search facets to use data from real API

### DIFF
--- a/mscr-ui/public/locales/en/common.json
+++ b/mscr-ui/public/locales/en/common.json
@@ -175,6 +175,13 @@
       "placeholder": "Search for...",
       "search-button": "Search"
     },
+    "facets": {
+      "format": "Format",
+      "isReferenced": "Source type",
+      "organization": "Organization",
+      "state": "State",
+      "type": "Type"
+    },
     "no-match": "No results matching search"
   },
   "search-by-keyword": "",

--- a/mscr-ui/public/locales/fi/common.json
+++ b/mscr-ui/public/locales/fi/common.json
@@ -173,6 +173,13 @@
       "placeholder": "",
       "search-button": ""
     },
+    "facets": {
+      "format": "",
+      "isReferenced": "",
+      "organization": "",
+      "state": "",
+      "type": ""
+    },
     "no-match": ""
   },
   "search-by-keyword": "",

--- a/mscr-ui/public/locales/sv/common.json
+++ b/mscr-ui/public/locales/sv/common.json
@@ -173,6 +173,13 @@
       "placeholder": "",
       "search-button": ""
     },
+    "facets": {
+      "format": "",
+      "isReferenced": "",
+      "organization": "",
+      "state": "",
+      "type": ""
+    },
     "no-match": ""
   },
   "search-by-keyword": "",

--- a/mscr-ui/src/common/components/mscr-search/mscr-search.slice.tsx
+++ b/mscr-ui/src/common/components/mscr-search/mscr-search.slice.tsx
@@ -21,9 +21,9 @@ function createUrl(urlState: UrlState) {
   if (urlState.format && urlState.format.length > 0) {
     baseQuery = baseQuery.concat(`&format=${urlState.format.join(',')}`);
   }
-  if (urlState.sourceType && urlState.sourceType.length > 0) {
+  if (urlState.isReferenced && urlState.isReferenced.length > 0) {
     baseQuery = baseQuery.concat(
-      `&sourceType=${urlState.sourceType.join(',')}`
+      `&sourceType=${urlState.isReferenced.join(',')}`
     );
   }
   if (urlState.organization && urlState.organization.length > 0) {
@@ -32,7 +32,7 @@ function createUrl(urlState: UrlState) {
     );
   }
 
-  return baseQuery;
+  return baseQuery.concat('&includeFacets=true');
 }
 
 export const mscrSearchApi = createApi({

--- a/mscr-ui/src/common/interfaces/search.interface.ts
+++ b/mscr-ui/src/common/interfaces/search.interface.ts
@@ -44,13 +44,13 @@ export interface MscrSearchResult {
   _source: ResultInfo;
 }
 
-export type Facet = 'state' | 'type' | 'format' | 'organization' | 'sourceType';
+export type Facet = 'state' | 'type' | 'format' | 'organization' | 'isReferenced';
 
 export interface Filter {
   label: string;
   facet: Facet;
   options: Array<{
-    label: string;
+    label?: string;
     key: string;
     count: number;
   }>;
@@ -58,7 +58,7 @@ export interface Filter {
 
 export interface Bucket {
   key: string;
-  label: string;
+  label?: string;
   doc_count: number;
 }
 

--- a/mscr-ui/src/common/interfaces/search.interface.ts
+++ b/mscr-ui/src/common/interfaces/search.interface.ts
@@ -44,7 +44,12 @@ export interface MscrSearchResult {
   _source: ResultInfo;
 }
 
-export type Facet = 'state' | 'type' | 'format' | 'organization' | 'isReferenced';
+export type Facet =
+  | 'state'
+  | 'type'
+  | 'format'
+  | 'organization'
+  | 'isReferenced';
 
 export interface Filter {
   label: string;

--- a/mscr-ui/src/common/utils/hooks/use-url-state.tsx
+++ b/mscr-ui/src/common/utils/hooks/use-url-state.tsx
@@ -13,7 +13,7 @@ export interface UrlState {
   state: string[];
   type: string[];
   format: string[];
-  sourceType: string[];
+  isReferenced: string[];
   sourceSchema: string[];
   targetSchema: string[];
   page: number;
@@ -27,7 +27,7 @@ export const initialUrlState: UrlState = {
   state: [],
   type: [],
   format: [],
-  sourceType: [],
+  isReferenced: [],
   sourceSchema: [],
   targetSchema: [],
   page: 1,
@@ -61,9 +61,9 @@ export default function useUrlState(): UseURLStateResult {
     state: asStringArray(router.query.state, initialUrlState.state),
     type: asStringArray(router.query.type, initialUrlState.type),
     format: asStringArray(router.query.format, initialUrlState.format),
-    sourceType: asStringArray(
-      router.query.sourceType,
-      initialUrlState.sourceType
+    isReferenced: asStringArray(
+      router.query.isReferenced,
+      initialUrlState.isReferenced
     ),
     sourceSchema: asStringArray(
       router.query.sourceSchema,
@@ -94,7 +94,7 @@ function updateURLState(router: NextRouter, urlState?: UrlState): void {
     state,
     type,
     format,
-    sourceType,
+    isReferenced,
     sourceSchema,
     targetSchema,
     page,
@@ -131,8 +131,8 @@ function buildUrlStatePatch(urlState: UrlState): Partial<UrlState> {
   if (!isInitial(urlState, 'state')) patch.state = urlState.state;
   if (!isInitial(urlState, 'type')) patch.type = urlState.type;
   if (!isInitial(urlState, 'format')) patch.format = urlState.format;
-  if (!isInitial(urlState, 'sourceType'))
-    patch.sourceType = urlState.sourceType;
+  if (!isInitial(urlState, 'isReferenced'))
+    patch.isReferenced = urlState.isReferenced;
   if (!isInitial(urlState, 'sourceSchema'))
     patch.sourceSchema = urlState.sourceSchema;
   if (!isInitial(urlState, 'targetSchema'))

--- a/mscr-ui/src/modules/search-screen/index.tsx
+++ b/mscr-ui/src/modules/search-screen/index.tsx
@@ -36,13 +36,21 @@ export default function SearchScreen() {
   };
 
   // Constructing filters
+  const facetTranslations = {
+    state: t('search.facets.state'),
+    type: t('search.facets.type'),
+    format: t('search.facets.format'),
+    organization: t('search.facets.organization'),
+    isReferenced: t('search.facets.isReferenced')
+  };
 
   const makeFilter = (key: string, buckets: Bucket[]): Filter => {
     const filterKey: Facet = key.substring(7) as Facet;
-    const filterLabel = t(filterKey);
+    const filterLabel = facetTranslations[filterKey];
     const options = buckets.map((bucket) => {
       return {
-        label: bucket.label,
+        // The keys work as labels for now, might change when we have organizations working
+        label: bucket.key,
         key: bucket.key,
         count: bucket.doc_count,
       };

--- a/mscr-ui/src/modules/search-screen/index.tsx
+++ b/mscr-ui/src/modules/search-screen/index.tsx
@@ -41,7 +41,7 @@ export default function SearchScreen() {
     type: t('search.facets.type'),
     format: t('search.facets.format'),
     organization: t('search.facets.organization'),
-    isReferenced: t('search.facets.isReferenced')
+    isReferenced: t('search.facets.isReferenced'),
   };
 
   const makeFilter = (key: string, buckets: Bucket[]): Filter => {


### PR DESCRIPTION
For now, the keys are displayed as labels for filtering options, but that only works because orrganization as a filter isn't implemented yet.