### PR TITLE
CSCFC4EMSCR-289 Change result limit in schema dropdown

### DIFF
--- a/mscr-ui/src/common/components/schema/schema.slice.tsx
+++ b/mscr-ui/src/common/components/schema/schema.slice.tsx
@@ -62,7 +62,7 @@ export const schemaApi = createApi({
     }),
     getPublicSchemas: builder.query<any, any>({
       query: () => ({
-        url: `/frontend/mscrSearch?type=SCHEMA`,
+        url: `/frontend/mscrSearch?type=SCHEMA&pageSize=100`,
         method: 'GET',
       }),
     }),


### PR DESCRIPTION
This is a quick fix to be able to see more schemas in the dropdown selector when creating crosswalk. Limit is now 100. Might need to adjust later, but it should be ok for now. Search works, so that way you don't need to look through everything.