### PR TITLE
CSCFC4EMSCR-325 Add pagination to content lists

### DIFF
--- a/mscr-ui/public/locales/en/common.json
+++ b/mscr-ui/public/locales/en/common.json
@@ -110,6 +110,15 @@
   "own-information": "",
   "page-indicator-text": "",
   "page-number": "",
+  "pagination": {
+    "aria": {
+      "info": "Page {{currentPage}} out of {{lastPage}}",
+      "label": "Pages",
+      "next": "Next page",
+      "prev": "Previous page"
+    },
+    "page": "Page"
+  },
   "previous-page": "",
   "profile": "",
   "profile-with-count_one": "",

--- a/mscr-ui/public/locales/fi/common.json
+++ b/mscr-ui/public/locales/fi/common.json
@@ -110,6 +110,15 @@
   "own-information": "",
   "page-indicator-text": "",
   "page-number": "",
+  "pagination": {
+    "aria": {
+      "info": "",
+      "label": "",
+      "next": "",
+      "prev": ""
+    },
+    "page": ""
+  },
   "previous-page": "",
   "profile": "",
   "profile-with-count_one": "",

--- a/mscr-ui/public/locales/sv/common.json
+++ b/mscr-ui/public/locales/sv/common.json
@@ -110,6 +110,15 @@
   "own-information": "",
   "page-indicator-text": "",
   "page-number": "",
+  "pagination": {
+    "aria": {
+      "info": "",
+      "label": "",
+      "next": "",
+      "prev": ""
+    },
+    "page": ""
+  },
   "previous-page": "",
   "profile": "",
   "profile-with-count_one": "",

--- a/mscr-ui/src/common/components/organization/organization.slice.tsx
+++ b/mscr-ui/src/common/components/organization/organization.slice.tsx
@@ -1,7 +1,11 @@
 import { createApi } from '@reduxjs/toolkit/query/react';
 import { getDatamodelApiBaseQuery } from '@app/store/api-base-query';
 import { HYDRATE } from 'next-redux-wrapper';
-import { MscrSearchResults } from '@app/common/interfaces/search.interface';
+import { MscrSearchResults, PaginatedQuery } from '@app/common/interfaces/search.interface';
+
+function createUrl({ type, ownerOrg, pageSize, pageFrom }: PaginatedQuery) {
+  return `/frontend/mscrSearchPersonalContent?query=&type=${type}&ownerOrg=${ownerOrg}&pageSize=${pageSize}&pageFrom=${pageFrom}`;
+}
 
 export const mscrSearchOrgContentApi = createApi({
   reducerPath: 'mscrSearchOrgContentApi',
@@ -13,9 +17,9 @@ export const mscrSearchOrgContentApi = createApi({
     }
   },
   endpoints: (builder) => ({
-    getOrgContent: builder.query<MscrSearchResults, { type: string; ownerOrg: string }>({
-      query: ({ type, ownerOrg }) => ({
-        url: `/frontend/mscrSearchOrgContent?query=&type=${type}&ownerOrg=${ownerOrg}`,
+    getOrgContent: builder.query<MscrSearchResults, PaginatedQuery>({
+      query: (query) => ({
+        url: createUrl(query),
         method: 'GET',
       }),
     }),

--- a/mscr-ui/src/common/components/pagination/index.tsx
+++ b/mscr-ui/src/common/components/pagination/index.tsx
@@ -1,0 +1,34 @@
+import { Dispatch, SetStateAction } from 'react';
+import { Pagination as SFPagination } from 'suomifi-ui-components';
+import { useTranslation } from 'next-i18next';
+
+interface PaginationProps {
+  currentPage: number;
+  setCurrentPage: Dispatch<SetStateAction<number>>;
+  lastPage: number;
+}
+
+export default function Pagination({
+  currentPage,
+  setCurrentPage,
+  lastPage,
+}: PaginationProps) {
+  const { t } = useTranslation('common');
+  return (
+    <SFPagination
+      aria-label={t('pagination.aria.label')}
+      pageIndicatorText={(currentPage, lastPage) =>
+        t('pagination.page') + ' ' + currentPage + ' / ' + lastPage
+      }
+      ariaPageIndicatorText={(currentPage, lastPage) =>
+        t('pagination.aria.info', { currentPage, lastPage })
+      }
+      lastPage={lastPage}
+      currentPage={currentPage}
+      onChange={(page) => setCurrentPage(+page)}
+      nextButtonAriaLabel={t('pagination.aria.next')}
+      previousButtonAriaLabel={t('pagination.aria.prev')}
+      pageInput={false}
+    />
+  );
+}

--- a/mscr-ui/src/common/components/personal/personal.slice.tsx
+++ b/mscr-ui/src/common/components/personal/personal.slice.tsx
@@ -1,7 +1,14 @@
 import { createApi } from '@reduxjs/toolkit/query/react';
 import { getDatamodelApiBaseQuery } from '@app/store/api-base-query';
 import { HYDRATE } from 'next-redux-wrapper';
-import { MscrSearchResults } from '@app/common/interfaces/search.interface';
+import {
+  MscrSearchResults,
+  PaginatedQuery,
+} from '@app/common/interfaces/search.interface';
+
+function createUrl({ type, pageSize, pageFrom }: PaginatedQuery) {
+  return `/frontend/mscrSearchPersonalContent?query=&type=${type}&pageSize=${pageSize}&pageFrom=${pageFrom}`;
+}
 
 export const mscrSearchPersonalContentApi = createApi({
   reducerPath: 'mscrSearchPersonalContentApi',
@@ -13,9 +20,9 @@ export const mscrSearchPersonalContentApi = createApi({
     }
   },
   endpoints: (builder) => ({
-    getPersonalContent: builder.query<MscrSearchResults, string>({
-      query: (type) => ({
-        url: `/frontend/mscrSearchPersonalContent?query=&type=${type}`,
+    getPersonalContent: builder.query<MscrSearchResults, PaginatedQuery>({
+      query: (query) => ({
+        url: createUrl(query),
         method: 'GET',
       }),
     }),

--- a/mscr-ui/src/common/interfaces/search.interface.ts
+++ b/mscr-ui/src/common/interfaces/search.interface.ts
@@ -33,6 +33,7 @@ export interface ResultInfo {
 export interface PaginatedQuery {
   query?: string;
   type?: Type;
+  ownerOrg?: string;
   pageSize: number;
   pageFrom: number;
 }

--- a/mscr-ui/src/common/interfaces/search.interface.ts
+++ b/mscr-ui/src/common/interfaces/search.interface.ts
@@ -30,10 +30,11 @@ export interface ResultInfo {
   format?: Format;
 }
 
-export interface PatchedResult extends ResultInfo {
-  description: {
-    [key: string]: string;
-  };
+export interface PaginatedQuery {
+  query?: string;
+  type?: Type;
+  pageSize: number;
+  pageFrom: number;
 }
 
 export interface MscrSearchResult {
@@ -47,16 +48,6 @@ export type Facet =
   | 'format'
   | 'organization'
   | 'isReferenced';
-
-export interface Filter {
-  label: string;
-  facet: Facet;
-  options: Array<{
-    label?: string;
-    key: string;
-    count: number;
-  }>;
-}
 
 export interface Bucket {
   key: string;
@@ -72,6 +63,9 @@ export interface Aggregations {
 
 export interface MscrSearchResults {
   hits: {
+    total?: {
+      value: number;
+    };
     hits: MscrSearchResult[];
   };
   aggregations: Aggregations;

--- a/mscr-ui/src/modules/search/search-screen/index.tsx
+++ b/mscr-ui/src/modules/search/search-screen/index.tsx
@@ -10,20 +10,17 @@ import useUrlState, {
   initialUrlState,
 } from '@app/common/utils/hooks/use-url-state';
 import { IconClose } from 'suomifi-icons';
-import { useContext, useEffect, useState } from 'react';
+import { useContext } from 'react';
 import { SearchContext } from '@app/common/components/search-context-provider';
 import SearchFilterSet from 'src/modules/search/search-filter-set';
 import { useTranslation } from 'next-i18next';
 import { Grid } from '@mui/material';
-import { useRouter } from 'next/router';
 
 export default function SearchScreen() {
   const { urlState, patchUrlState } = useUrlState();
   const { t } = useTranslation('common');
   const { setIsSearchActive } = useContext(SearchContext);
   const { data: mscrSearchResults } = useGetMscrSearchResultsQuery(urlState);
-  const { query, pathname } = useRouter();
-  const [currentPath] = useState(pathname);
 
   const handleClose = () => {
     setIsSearchActive(false);

--- a/mscr-ui/src/modules/workspace/group-home/index.tsx
+++ b/mscr-ui/src/modules/workspace/group-home/index.tsx
@@ -4,18 +4,25 @@ import { useTranslation } from 'next-i18next';
 import { useBreakpoints } from 'yti-common-ui/components/media-query';
 import WorkspaceTable from '@app/modules/workspace/workspace-table';
 import Title from 'yti-common-ui/components/title';
-import { Description, TitleDescriptionWrapper } from 'yti-common-ui/components/title/title.styles';
+import {
+  Description,
+  TitleDescriptionWrapper,
+} from 'yti-common-ui/components/title/title.styles';
 import Separator from 'yti-common-ui/components/separator';
 import { MscrUser } from '@app/common/interfaces/mscr-user.interface';
 import { useState } from 'react';
-import { Pagination } from 'suomifi-ui-components';
+import Pagination from '@app/common/components/pagination';
 
 interface GroupHomeProps {
   user: MscrUser;
   pid: string;
   contentType: Type;
 }
-export default function GroupWorkspace({ user, pid, contentType }: GroupHomeProps) {
+export default function GroupWorkspace({
+  user,
+  pid,
+  contentType,
+}: GroupHomeProps) {
   const { t, i18n } = useTranslation('common');
   const { isSmall } = useBreakpoints();
   const [currentPage, setCurrentPage] = useState(1);
@@ -75,19 +82,9 @@ export default function GroupWorkspace({ user, pid, contentType }: GroupHomeProp
         )}
         {lastPage > 1 && (
           <Pagination
-            aria-label={t('pagination.aria.label')}
-            pageIndicatorText={(currentPage, lastPage) =>
-              t('pagination.page') + ' ' + currentPage + ' / ' + lastPage
-            }
-            ariaPageIndicatorText={(currentPage, lastPage) =>
-              t('pagination.aria.info', { currentPage, lastPage })
-            }
-            lastPage={lastPage}
             currentPage={currentPage}
-            onChange={(page) => setCurrentPage(+page)}
-            nextButtonAriaLabel={t('pagination.aria.next')}
-            previousButtonAriaLabel={t('pagination.aria.prev')}
-            pageInput={false}
+            setCurrentPage={setCurrentPage}
+            lastPage={lastPage}
           />
         )}
       </main>

--- a/mscr-ui/src/modules/workspace/personal-home/index.tsx
+++ b/mscr-ui/src/modules/workspace/personal-home/index.tsx
@@ -28,7 +28,7 @@ export default function PersonalWorkspace({
   const query: PaginatedQuery = {
     type: contentType,
     pageSize,
-    pageFrom: (+currentPage - 1) * pageSize,
+    pageFrom: (currentPage - 1) * pageSize,
   };
   const { data, isLoading } = useGetPersonalContentQuery(query);
   const lastPage = data?.hits.total?.value

--- a/mscr-ui/src/modules/workspace/personal-home/index.tsx
+++ b/mscr-ui/src/modules/workspace/personal-home/index.tsx
@@ -14,7 +14,7 @@ import { useGetOrganizationsQuery } from '@app/common/components/organizations/o
 import CrosswalkFormModal from '@app/modules/form/crosswalk-form/crosswalk-form-modal';
 import { ButtonBlock } from '@app/modules/workspace/workspace.styles';
 import { useState } from 'react';
-import { Pagination } from 'suomifi-ui-components';
+import Pagination from '@app/common/components/pagination';
 
 export default function PersonalWorkspace({
   contentType,
@@ -87,19 +87,9 @@ export default function PersonalWorkspace({
         )}
         {lastPage > 1 && (
           <Pagination
-            aria-label={t('pagination.aria.label')}
-            pageIndicatorText={(currentPage, lastPage) =>
-              t('pagination.page') + ' ' + currentPage + ' / ' + lastPage
-            }
-            ariaPageIndicatorText={(currentPage, lastPage) =>
-              t('pagination.aria.info', { currentPage, lastPage })
-            }
-            lastPage={lastPage}
             currentPage={currentPage}
-            onChange={(page) => setCurrentPage(+page)}
-            nextButtonAriaLabel={t('pagination.aria.next')}
-            previousButtonAriaLabel={t('pagination.aria.prev')}
-            pageInput={false}
+            setCurrentPage={setCurrentPage}
+            lastPage={lastPage}
           />
         )}
       </main>

--- a/mscr-ui/src/modules/workspace/personal-home/index.tsx
+++ b/mscr-ui/src/modules/workspace/personal-home/index.tsx
@@ -87,18 +87,18 @@ export default function PersonalWorkspace({
         )}
         {lastPage > 1 && (
           <Pagination
-            aria-label={t('pagination-label')}
+            aria-label={t('pagination.aria.label')}
             pageIndicatorText={(currentPage, lastPage) =>
               t('pagination.page') + ' ' + currentPage + ' / ' + lastPage
             }
             ariaPageIndicatorText={(currentPage, lastPage) =>
-              t('pagination.aria', { currentPage, lastPage })
+              t('pagination.aria.info', { currentPage, lastPage })
             }
             lastPage={lastPage}
             currentPage={currentPage}
             onChange={(page) => setCurrentPage(+page)}
-            nextButtonAriaLabel={t('pagination.aria-next')}
-            previousButtonAriaLabel={t('pagination.aria-prev')}
+            nextButtonAriaLabel={t('pagination.aria.next')}
+            previousButtonAriaLabel={t('pagination.aria.prev')}
             pageInput={false}
           />
         )}


### PR DESCRIPTION
This actually solves a pretty big issue we have for now, that only first 10 items of content can be viewed through the content pages. I didn't use the Pagination component from common-ui, because I wanted it to be a simpler one for now that we don't have designs for it yet. So this one doesn't update url with page info and doesn't have a page input.