### PR TITLE
CSCFC4EMSCR-358 Schema visualization in schema detail

### DIFF
--- a/mscr-ui/public/locales/en/common.json
+++ b/mscr-ui/public/locales/en/common.json
@@ -189,6 +189,8 @@
     "status-select": "Select status"
   },
   "schema-tree": {
+    "error-heading": "Visualization not available",
+    "error-info": "Cannot show tree view for schemas of this format, download the file instead in Metadata and files tab.",
     "filter-schema": "Select from schema"
   },
   "search": {

--- a/mscr-ui/public/locales/en/common.json
+++ b/mscr-ui/public/locales/en/common.json
@@ -196,6 +196,7 @@
     "error-info": "Cannot show tree view for schemas of this format, download the file instead in Metadata and files tab.",
     "expand": "Expand tree",
     "filter-schema": "Select from schema",
+    "node-info": "Selected node info",
     "search": "Search",
     "search-placeholder": "Find an attribute...",
     "selected-node": "Selected node:",

--- a/mscr-ui/public/locales/en/common.json
+++ b/mscr-ui/public/locales/en/common.json
@@ -189,9 +189,17 @@
     "status-select": "Select status"
   },
   "schema-tree": {
+    "clear": "Clear",
+    "dropdown-label": "Selected nodes",
+    "dropdown-placeholder": "Node(s) not selected",
     "error-heading": "Visualization not available",
     "error-info": "Cannot show tree view for schemas of this format, download the file instead in Metadata and files tab.",
-    "filter-schema": "Select from schema"
+    "expand": "Expand tree",
+    "filter-schema": "Select from schema",
+    "search": "Search",
+    "search-placeholder": "Find an attribute...",
+    "selected-node": "Selected node:",
+    "tree-label": "Schema tree"
   },
   "search": {
     "bar": {

--- a/mscr-ui/public/locales/en/common.json
+++ b/mscr-ui/public/locales/en/common.json
@@ -188,6 +188,9 @@
     "status": "Status",
     "status-select": "Select status"
   },
+  "schema-tree": {
+    "filter-schema": "Select from schema"
+  },
   "search": {
     "bar": {
       "clear-button": "Clear input and close search",
@@ -249,6 +252,7 @@
   "synonym": "",
   "tabs": {
     "metadata-and-files": "Metadata and files",
+    "schema": "Schema",
     "version-history": "Version history"
   },
   "term-conjugation": {

--- a/mscr-ui/public/locales/fi/common.json
+++ b/mscr-ui/public/locales/fi/common.json
@@ -191,9 +191,17 @@
     "status-select": ""
   },
   "schema-tree": {
+    "clear": "",
+    "dropdown-label": "",
+    "dropdown-placeholder": "",
     "error-heading": "",
     "error-info": "",
-    "filter-schema": ""
+    "expand": "",
+    "filter-schema": "",
+    "search": "",
+    "search-placeholder": "",
+    "selected-node": "",
+    "tree-label": ""
   },
   "search": {
     "bar": {

--- a/mscr-ui/public/locales/fi/common.json
+++ b/mscr-ui/public/locales/fi/common.json
@@ -198,6 +198,7 @@
     "error-info": "",
     "expand": "",
     "filter-schema": "",
+    "node-info": "",
     "search": "",
     "search-placeholder": "",
     "selected-node": "",

--- a/mscr-ui/public/locales/fi/common.json
+++ b/mscr-ui/public/locales/fi/common.json
@@ -190,6 +190,9 @@
     "status": "",
     "status-select": ""
   },
+  "schema-tree": {
+    "filter-schema": ""
+  },
   "search": {
     "bar": {
       "clear-button": "",
@@ -251,6 +254,7 @@
   "synonym": "",
   "tabs": {
     "metadata-and-files": "",
+    "schema": "",
     "version-history": ""
   },
   "term-conjugation": {

--- a/mscr-ui/public/locales/fi/common.json
+++ b/mscr-ui/public/locales/fi/common.json
@@ -191,6 +191,8 @@
     "status-select": ""
   },
   "schema-tree": {
+    "error-heading": "",
+    "error-info": "",
     "filter-schema": ""
   },
   "search": {

--- a/mscr-ui/public/locales/sv/common.json
+++ b/mscr-ui/public/locales/sv/common.json
@@ -191,9 +191,17 @@
     "status-select": ""
   },
   "schema-tree": {
+    "clear": "",
+    "dropdown-label": "",
+    "dropdown-placeholder": "",
     "error-heading": "",
     "error-info": "",
-    "filter-schema": ""
+    "expand": "",
+    "filter-schema": "",
+    "search": "",
+    "search-placeholder": "",
+    "selected-node": "",
+    "tree-label": ""
   },
   "search": {
     "bar": {

--- a/mscr-ui/public/locales/sv/common.json
+++ b/mscr-ui/public/locales/sv/common.json
@@ -198,6 +198,7 @@
     "error-info": "",
     "expand": "",
     "filter-schema": "",
+    "node-info": "",
     "search": "",
     "search-placeholder": "",
     "selected-node": "",

--- a/mscr-ui/public/locales/sv/common.json
+++ b/mscr-ui/public/locales/sv/common.json
@@ -190,6 +190,9 @@
     "status": "",
     "status-select": ""
   },
+  "schema-tree": {
+    "filter-schema": ""
+  },
   "search": {
     "bar": {
       "clear-button": "",
@@ -251,6 +254,7 @@
   "synonym": "",
   "tabs": {
     "metadata-and-files": "",
+    "schema": "",
     "version-history": ""
   },
   "term-conjugation": {

--- a/mscr-ui/public/locales/sv/common.json
+++ b/mscr-ui/public/locales/sv/common.json
@@ -191,6 +191,8 @@
     "status-select": ""
   },
   "schema-tree": {
+    "error-heading": "",
+    "error-info": "",
     "filter-schema": ""
   },
   "search": {

--- a/mscr-ui/src/common/components/schema-info/index.tsx
+++ b/mscr-ui/src/common/components/schema-info/index.tsx
@@ -15,7 +15,10 @@ import { useGetFrontendSchemaQuery } from '@app/common/components/schema/schema.
 const inputData: RenderTree[] = [];
 
 export default function SchemaInfo(props: {
-  updateTreeNodeSelectionsOutput?: any;
+  updateTreeNodeSelectionsOutput?: (
+    nodeIds: RenderTree[],
+    isSourceSchema: boolean
+  ) => void;
   isSourceTree?: boolean;
   treeSelection?: string[];
   caption: string;
@@ -85,10 +88,13 @@ export default function SchemaInfo(props: {
   useEffect(() => {
     // Update selections for node info and parent component for mappings
     const selectedTreeNodeIds = getTreeNodesByIds(treeSelectedArray);
-    if (props.updateTreeNodeSelectionsOutput && props.isSourceTree !== undefined) {
+    if (
+      props.updateTreeNodeSelectionsOutput &&
+      props.isSourceTree !== undefined
+    ) {
       props.updateTreeNodeSelectionsOutput(
         selectedTreeNodeIds,
-        props.isSourceTree,
+        props.isSourceTree
       );
     }
     setSelectedTreeNodes(selectedTreeNodeIds);
@@ -114,9 +120,9 @@ export default function SchemaInfo(props: {
 
   // Used to tree filtering
   function findNodesFromTree(
-    tree: any,
+    tree: RenderTree[],
     itemsToFind: string[],
-    results: RenderTree[],
+    results: RenderTree[]
   ) {
     tree.forEach((item: RenderTree) => {
       if (itemsToFind.includes(item.id)) {
@@ -139,7 +145,7 @@ export default function SchemaInfo(props: {
   function doFiltering(
     tree: RenderTree[],
     nameToFind: string,
-    results: { nodeIds: string[]; childNodeIds: string[] },
+    results: { nodeIds: string[]; childNodeIds: string[] }
   ) {
     tree.forEach((item) => {
       if (
@@ -163,7 +169,7 @@ export default function SchemaInfo(props: {
   function getElementPathsFromTree(
     treeData: RenderTree[],
     nodeIds: string[],
-    results: string[],
+    results: string[]
   ) {
     treeData.forEach((item) => {
       if (nodeIds.includes(item.id)) {
@@ -212,48 +218,38 @@ export default function SchemaInfo(props: {
     }
   }
 
-  function searchFromTree(input: any) {
+  function searchFromTree(input: string) {
     clearTreeSearch();
     const hits = { nodeIds: [], childNodeIds: [] };
     doFiltering(treeData, input.toString(), hits);
     expandAndSelectNodes(hits.nodeIds);
   }
 
-  function handleTreeClick(
-    event: React.SyntheticEvent | undefined,
-    nodeIds: string[],
-  ) {
+  function handleTreeClick(nodeIds: string[]) {
     setTreeSelections(nodeIds);
   }
 
-  function handleTreeToggle(
-    event: React.SyntheticEvent | undefined,
-    nodeIds: string[],
-  ) {
+  function handleTreeToggle(nodeIds: string[]) {
     setTreeExpanded(nodeIds);
   }
 
-  const selectFromTreeById = (nodeId: string) => {
-    const nodeIds = [];
-    nodeIds.push(nodeId);
-    expandAndSelectNodes(nodeIds);
-  };
+  // const selectFromTreeById = (nodeId: string) => {
+  //   const nodeIds = [];
+  //   nodeIds.push(nodeId);
+  //   expandAndSelectNodes(nodeIds);
+  // };
 
-  const performCallbackFromTreeAction = (
-    action: any,
-    event: any,
-    nodeIds: any,
-  ) => {
+  const performCallbackFromTreeAction = (action: string, nodeIds: string[]) => {
     if (action === 'handleSelect') {
-      handleTreeClick(event, nodeIds);
+      handleTreeClick(nodeIds);
     } else if (action === 'treeToggle') {
-      handleTreeToggle(event, nodeIds);
+      handleTreeToggle(nodeIds);
     }
   };
 
-  const performNodeInfoAction = (nodeId: any, isSourceTree: boolean) => {
-    selectFromTreeById(nodeId);
-  };
+  // const performNodeInfoAction = (nodeId: any, isSourceTree: boolean) => {
+  //   selectFromTreeById(nodeId);
+  // };
 
   return (
     <>
@@ -268,7 +264,9 @@ export default function SchemaInfo(props: {
                 clearButtonLabel="Clear"
                 visualPlaceholder="Find an attribute..."
                 onSearch={(value) => {
-                  searchFromTree(value);
+                  if (typeof value === 'string') {
+                    searchFromTree(value);
+                  }
                 }}
                 onChange={(value) => {
                   if (!value) {
@@ -315,7 +313,7 @@ export default function SchemaInfo(props: {
         <div className="col-5 px-0 node-info-wrap">
           <NodeInfo
             treeData={selectedTreeNodes}
-            performNodeInfoAction={performNodeInfoAction}
+            // performNodeInfoAction={performNodeInfoAction}
           ></NodeInfo>
         </div>
       </div>

--- a/mscr-ui/src/common/components/schema-info/index.tsx
+++ b/mscr-ui/src/common/components/schema-info/index.tsx
@@ -42,8 +42,9 @@ export default function SchemaInfo(props: {
     error: getSchemaDataError,
   } = useGetFrontendSchemaQuery(props.schemaUrn);
 
-  const [treeDataOriginal, setTreeDataOriginal] =
-    React.useState<RenderTree[]>([]);
+  const [treeDataOriginal, setTreeDataOriginal] = React.useState<RenderTree[]>(
+    []
+  );
   const [treeData, setTreeData] = React.useState<RenderTree[]>([]);
   const [treeExpandedArray, setTreeExpanded] = React.useState<string[]>([]);
 
@@ -278,7 +279,7 @@ export default function SchemaInfo(props: {
             <div className="expand-button-wrap">
               <IconButton
                 onClick={() => handleExpandClick()}
-                aria-label= {t('schema-tree.expand')}
+                aria-label={t('schema-tree.expand')}
                 color="primary"
                 size="large"
               >

--- a/mscr-ui/src/common/components/schema-info/index.tsx
+++ b/mscr-ui/src/common/components/schema-info/index.tsx
@@ -77,16 +77,20 @@ export default function SchemaInfo(props: {
 
   // Expand and select nodes when input changed (from mappings accordion)
   useEffect(() => {
-    expandAndSelectNodes(props.treeSelection);
+    if (props.treeSelection) {
+      expandAndSelectNodes(props.treeSelection);
+    }
   }, [props.treeSelection]);
 
   useEffect(() => {
     // Update selections for node info and parent component for mappings
     const selectedTreeNodeIds = getTreeNodesByIds(treeSelectedArray);
-    props.updateTreeNodeSelectionsOutput(
-      selectedTreeNodeIds,
-      props.isSourceTree,
-    );
+    if (props.updateTreeNodeSelectionsOutput && props.isSourceTree !== undefined) {
+      props.updateTreeNodeSelectionsOutput(
+        selectedTreeNodeIds,
+        props.isSourceTree,
+      );
+    }
     setSelectedTreeNodes(selectedTreeNodeIds);
   }, [treeSelectedArray]);
 

--- a/mscr-ui/src/common/components/schema-info/index.tsx
+++ b/mscr-ui/src/common/components/schema-info/index.tsx
@@ -12,6 +12,11 @@ import { cloneDeep } from 'lodash';
 import { generateTreeFromJson } from '@app/common/components/schema-info/schema-tree/schema-tree-renderer';
 import { useGetFrontendSchemaQuery } from '@app/common/components/schema/schema.slice';
 import { useTranslation } from 'next-i18next';
+import {
+  ExpandButtonWrapper,
+  NodeInfoWrapper,
+  SearchWrapper
+} from '@app/common/components/schema-info/schema-info.styles';
 
 export default function SchemaInfo(props: {
   updateTreeNodeSelectionsOutput?: (
@@ -257,7 +262,7 @@ export default function SchemaInfo(props: {
       <div className="row content-box">
         <div className="col-7 px-0">
           <div className="d-flex justify-content-between mb-2 ps-3 pe-2">
-            <div className="w-100">
+            <SearchWrapper className="w-100">
               <SearchInput
                 className="py-2"
                 labelText={props.caption}
@@ -275,8 +280,8 @@ export default function SchemaInfo(props: {
                   }
                 }}
               />
-            </div>
-            <div className="expand-button-wrap">
+            </SearchWrapper>
+            <ExpandButtonWrapper>
               <IconButton
                 onClick={() => handleExpandClick()}
                 aria-label={t('schema-tree.expand')}
@@ -289,7 +294,7 @@ export default function SchemaInfo(props: {
                   <ExpandLessIcon />
                 )}
               </IconButton>
-            </div>
+            </ExpandButtonWrapper>
           </div>
           <div className="mx-2">
             <Box
@@ -311,12 +316,12 @@ export default function SchemaInfo(props: {
             </Box>
           </div>
         </div>
-        <div className="col-5 px-0 node-info-wrap">
+        <NodeInfoWrapper className="col-5 px-0">
           <NodeInfo
             treeData={selectedTreeNodes}
             // performNodeInfoAction={performNodeInfoAction}
           ></NodeInfo>
-        </div>
+        </NodeInfoWrapper>
       </div>
     </>
   );

--- a/mscr-ui/src/common/components/schema-info/index.tsx
+++ b/mscr-ui/src/common/components/schema-info/index.tsx
@@ -11,6 +11,7 @@ import { RenderTree } from '@app/common/interfaces/crosswalk-connection.interfac
 import { cloneDeep } from 'lodash';
 import { generateTreeFromJson } from '@app/common/components/schema-info/schema-tree/schema-tree-renderer';
 import { useGetFrontendSchemaQuery } from '@app/common/components/schema/schema.slice';
+import { useTranslation } from 'next-i18next';
 
 export default function SchemaInfo(props: {
   updateTreeNodeSelectionsOutput?: (
@@ -22,6 +23,7 @@ export default function SchemaInfo(props: {
   caption: string;
   schemaUrn: string;
 }) {
+  const { t } = useTranslation('common');
   const emptyTreeSelection: RenderTree = {
     elementPath: '',
     parentElementPath: undefined,
@@ -258,9 +260,9 @@ export default function SchemaInfo(props: {
               <SearchInput
                 className="py-2"
                 labelText={props.caption}
-                searchButtonLabel="Search"
-                clearButtonLabel="Clear"
-                visualPlaceholder="Find an attribute..."
+                searchButtonLabel={t('schema-tree.search')}
+                clearButtonLabel={t('schema-tree.clear')}
+                visualPlaceholder={t('schema-tree.search-placeholder')}
                 onSearch={(value) => {
                   if (typeof value === 'string') {
                     searchFromTree(value);
@@ -276,7 +278,7 @@ export default function SchemaInfo(props: {
             <div className="expand-button-wrap">
               <IconButton
                 onClick={() => handleExpandClick()}
-                aria-label="expand tree"
+                aria-label= {t('schema-tree.expand')}
                 color="primary"
                 size="large"
               >

--- a/mscr-ui/src/common/components/schema-info/index.tsx
+++ b/mscr-ui/src/common/components/schema-info/index.tsx
@@ -12,8 +12,6 @@ import { cloneDeep } from 'lodash';
 import { generateTreeFromJson } from '@app/common/components/schema-info/schema-tree/schema-tree-renderer';
 import { useGetFrontendSchemaQuery } from '@app/common/components/schema/schema.slice';
 
-const inputData: RenderTree[] = [];
-
 export default function SchemaInfo(props: {
   updateTreeNodeSelectionsOutput?: (
     nodeIds: RenderTree[],
@@ -43,8 +41,8 @@ export default function SchemaInfo(props: {
   } = useGetFrontendSchemaQuery(props.schemaUrn);
 
   const [treeDataOriginal, setTreeDataOriginal] =
-    React.useState<RenderTree[]>(inputData);
-  const [treeData, setTreeData] = React.useState<RenderTree[]>(inputData);
+    React.useState<RenderTree[]>([]);
+  const [treeData, setTreeData] = React.useState<RenderTree[]>([]);
   const [treeExpandedArray, setTreeExpanded] = React.useState<string[]>([]);
 
   // These are used by tree visualization

--- a/mscr-ui/src/common/components/schema-info/schema-info.styles.tsx
+++ b/mscr-ui/src/common/components/schema-info/schema-info.styles.tsx
@@ -1,0 +1,79 @@
+import styled from 'styled-components';
+
+export const ExpandButtonWrapper = styled.div`
+  margin-top: 37px;
+  margin-right: 15px;
+`;
+
+export const SearchWrapper = styled.div`
+  && .fi-search-input {
+    width: 100%;
+  }
+`;
+
+export const DropdownWrapper = styled.div`
+  margin-top: -5px;
+  margin-bottom: 15px;
+
+  && .fi-dropdown_button {
+    min-width: 100%;
+    width: 100%;
+  }
+
+  .fi-dropdown {
+    width: 100%;
+  }
+`;
+
+export const NodeInfoWrapper = styled.div`
+  color: #6b6b6b;
+  background: #d8e3f4;
+
+  .node-info-box {
+    min-height: 175px;
+    font-size: 0.95rem;
+    margin: 0;
+
+    .source-to-destination-wrap {
+      min-height: 42px;
+
+      button {
+        padding: 0;
+      }
+
+      .arrow-icon {
+        margin: 0 15px;
+        font-size: 1.3rem;
+      }
+    }
+  }
+
+  .attribute-font {
+    font-size: 0.9rem;
+    line-height: 1.3rem;
+    margin-bottom: 2px;
+    color: #2b2b2b;
+    margin-top: -2px;
+    inline-size: 100%;
+    overflow-wrap: break-word;
+  }
+
+  h3 {
+    font-size: 1.1rem;
+    font-weight: normal;
+    margin-bottom: 0;
+    padding: 17px 14px 0 17px;
+  }
+
+  .side-bar-wrap {
+    padding: 5px 5px;
+  }
+
+  .bg-wrap {
+    font-size: 0.95rem;
+    background: #fff;
+    padding: 15px;
+    min-height: 377px;
+    max-width: 500px;
+  }
+`;

--- a/mscr-ui/src/common/components/schema-info/schema-tree/index.tsx
+++ b/mscr-ui/src/common/components/schema-info/schema-tree/index.tsx
@@ -4,6 +4,7 @@ import TreeItem from '@mui/lab/TreeItem';
 import { useEffect } from 'react';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import { useTranslation } from 'next-i18next';
 
 function toTree(nodes: any) {
   let ret = undefined;
@@ -50,6 +51,7 @@ export default function SchemaTree({
   treeExpanded: string[];
   performTreeAction: (action: string, nodeIds: string[]) => void;
 }) {
+  const { t } = useTranslation('common');
 
   const handleSelect = (event: React.SyntheticEvent, nodeIds: string[]) => {
     performTreeAction('handleSelect', nodeIds);
@@ -62,7 +64,7 @@ export default function SchemaTree({
   // console.log('TREEVIEW DATA', nodes, treeSelectedArray);
   return (
     <TreeView
-      aria-label="controlled"
+      aria-label= {t('schema-tree.tree-label')} // "controlled"
       expanded={treeExpanded}
       selected={treeSelectedArray}
       onNodeSelect={handleSelect}

--- a/mscr-ui/src/common/components/schema-info/schema-tree/index.tsx
+++ b/mscr-ui/src/common/components/schema-info/schema-tree/index.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import TreeView from '@mui/lab/TreeView';
 import TreeItem from '@mui/lab/TreeItem';
-import { useEffect } from 'react';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import { useTranslation } from 'next-i18next';
+import { RenderTree } from '@app/common/interfaces/crosswalk-connection.interface';
 
-function toTree(nodes: any) {
+function toTree(nodes: RenderTree) {
   let ret = undefined;
   if (Array.isArray(nodes)) {
     return nodes.map((node) => {
@@ -18,7 +18,7 @@ function toTree(nodes: any) {
           className="linked-tree-item"
         >
           {Array.isArray(node.children)
-            ? node.children.map((node: any) => toTree(node))
+            ? node.children.map((node: RenderTree) => toTree(node))
             : null}
         </TreeItem>
       );
@@ -32,7 +32,7 @@ function toTree(nodes: any) {
         className="linked-tree-item"
       >
         {Array.isArray(nodes.children)
-          ? nodes.children.map((node: any) => toTree(node))
+          ? nodes.children.map((node: RenderTree) => toTree(node))
           : null}
       </TreeItem>
     );
@@ -46,7 +46,7 @@ export default function SchemaTree({
   treeExpanded,
   performTreeAction,
 }: {
-  nodes: any;
+  nodes: RenderTree;
   treeSelectedArray: string[];
   treeExpanded: string[];
   performTreeAction: (action: string, nodeIds: string[]) => void;
@@ -80,7 +80,7 @@ export default function SchemaTree({
         className="linked-tree-item"
       >
         {Array.isArray(nodes.children)
-          ? nodes.children.map((node: any) => toTree(node))
+          ? nodes.children.map((node: RenderTree) => toTree(node))
           : null}
       </TreeItem>
     </TreeView>

--- a/mscr-ui/src/common/components/schema-info/schema-tree/index.tsx
+++ b/mscr-ui/src/common/components/schema-info/schema-tree/index.tsx
@@ -64,7 +64,7 @@ export default function SchemaTree({
   // console.log('TREEVIEW DATA', nodes, treeSelectedArray);
   return (
     <TreeView
-      aria-label= {t('schema-tree.tree-label')} // "controlled"
+      aria-label={t('schema-tree.tree-label')}
       expanded={treeExpanded}
       selected={treeSelectedArray}
       onNodeSelect={handleSelect}

--- a/mscr-ui/src/common/components/schema-info/schema-tree/index.tsx
+++ b/mscr-ui/src/common/components/schema-info/schema-tree/index.tsx
@@ -48,15 +48,15 @@ export default function SchemaTree({
   nodes: any;
   treeSelectedArray: string[];
   treeExpanded: string[];
-  performTreeAction: any;
+  performTreeAction: (action: string, nodeIds: string[]) => void;
 }) {
 
   const handleSelect = (event: React.SyntheticEvent, nodeIds: string[]) => {
-    performTreeAction('handleSelect', event, nodeIds);
+    performTreeAction('handleSelect', nodeIds);
   };
 
   const handleToggle = (event: React.SyntheticEvent, nodeIds: string[]) => {
-    performTreeAction('treeToggle', event, nodeIds);
+    performTreeAction('treeToggle', nodeIds);
   };
 
   // console.log('TREEVIEW DATA', nodes, treeSelectedArray);

--- a/mscr-ui/src/common/components/schema-info/schema-tree/node-info/index.tsx
+++ b/mscr-ui/src/common/components/schema-info/schema-tree/node-info/index.tsx
@@ -3,11 +3,13 @@ import { Dropdown, DropdownItem } from 'suomifi-ui-components';
 import { useState, useEffect } from 'react';
 import Box from '@mui/material/Box';
 import { InfoIcon } from '@app/common/components/shared-icons';
+import { useTranslation } from 'next-i18next';
 
 export default function NodeInfo(props: {
   treeData: RenderTree[];
   // performNodeInfoAction: any;
 }) {
+  const { t } = useTranslation('common');
   let sourceSelectionInit = '';
 
   useEffect(() => {
@@ -24,7 +26,7 @@ export default function NodeInfo(props: {
     (item) => item.id === sourceDropdownValue,
   );
 
-  let dropdownInit: any = [
+  let dropdownInit: {id: string; name?: string}[] = [
     {
       id: '1',
     },
@@ -95,8 +97,10 @@ export default function NodeInfo(props: {
           {props.treeData.length > 1 && (
             <div className="dropdown-wrap">
               <Dropdown
+                labelText={t('schema-tree.dropdown-label')}
+                labelMode={'hidden'}
                 className="mt-2 node-info-dropdown"
-                visualPlaceholder="Node(s) not selected"
+                visualPlaceholder= {t('schema-tree.dropdown-placeholder')}
                 value={sourceDropdownValue}
                 onChange={(newValue) => setDropdownValue(newValue)}
               >
@@ -113,7 +117,7 @@ export default function NodeInfo(props: {
               {props.treeData.length > 1 && (
                 <>
                   <div className="col-12">
-                    <div>Selected node:</div>
+                    <div>{t('schema-tree.selected-node')}</div>
                     <div className="attribute-font">{selectedNode?.name}</div>
                   </div>
                 </>

--- a/mscr-ui/src/common/components/schema-info/schema-tree/node-info/index.tsx
+++ b/mscr-ui/src/common/components/schema-info/schema-tree/node-info/index.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import Box from '@mui/material/Box';
 import { InfoIcon } from '@app/common/components/shared-icons';
 import { useTranslation } from 'next-i18next';
+import { DropdownWrapper } from '@app/common/components/schema-info/schema-info.styles';
 
 export default function NodeInfo(props: {
   treeData: RenderTree[];
@@ -62,7 +63,7 @@ export default function NodeInfo(props: {
 
   return (
     <div className="row d-flex justify-content-between node-info-box">
-      <h2>Selected node info</h2>
+      <h3>{t('schema-tree.node-info')}</h3>
       <div className="col flex-column d-flex justify-content-between side-bar-wrap">
         <div className="mb-2"></div>
         <Box
@@ -92,11 +93,11 @@ export default function NodeInfo(props: {
             </>
           )}
           {props.treeData.length > 1 && (
-            <div className="dropdown-wrap">
+            <DropdownWrapper>
               <Dropdown
                 labelText={t('schema-tree.dropdown-label')}
                 labelMode={'hidden'}
-                className="mt-2 node-info-dropdown"
+                className="mt-2"
                 visualPlaceholder={t('schema-tree.dropdown-placeholder')}
                 value={sourceDropdownValue}
                 onChange={(newValue) => setDropdownValue(newValue)}
@@ -107,7 +108,7 @@ export default function NodeInfo(props: {
                   </DropdownItem>
                 ))}
               </Dropdown>
-            </div>
+            </DropdownWrapper>
           )}
           <div>
             <div className="row">

--- a/mscr-ui/src/common/components/schema-info/schema-tree/node-info/index.tsx
+++ b/mscr-ui/src/common/components/schema-info/schema-tree/node-info/index.tsx
@@ -20,13 +20,12 @@ export default function NodeInfo(props: {
     }
   }, [props]);
 
-  const [sourceDropdownValue, setDropdownValue] =
-    useState(sourceSelectionInit);
+  const [sourceDropdownValue, setDropdownValue] = useState(sourceSelectionInit);
   const [selectedNode] = props.treeData.filter(
-    (item) => item.id === sourceDropdownValue,
+    (item) => item.id === sourceDropdownValue
   );
 
-  let dropdownInit: {id: string; name?: string}[] = [
+  let dropdownInit: { id: string; name?: string }[] = [
     {
       id: '1',
     },
@@ -42,9 +41,7 @@ export default function NodeInfo(props: {
 
   const nodeProperties: constantAttribute[] = [];
   if (props.treeData.length > 0 && props.treeData[0]?.properties) {
-    for (const [key, value] of Object.entries(
-      props.treeData[0]?.properties,
-    )) {
+    for (const [key, value] of Object.entries(props.treeData[0]?.properties)) {
       nodeProperties.push({
         name: key,
         value: typeof value === 'string' ? value.toString() : undefined,
@@ -100,7 +97,7 @@ export default function NodeInfo(props: {
                 labelText={t('schema-tree.dropdown-label')}
                 labelMode={'hidden'}
                 className="mt-2 node-info-dropdown"
-                visualPlaceholder= {t('schema-tree.dropdown-placeholder')}
+                visualPlaceholder={t('schema-tree.dropdown-placeholder')}
                 value={sourceDropdownValue}
                 onChange={(newValue) => setDropdownValue(newValue)}
               >

--- a/mscr-ui/src/common/components/schema-info/schema-tree/node-info/index.tsx
+++ b/mscr-ui/src/common/components/schema-info/schema-tree/node-info/index.tsx
@@ -1,13 +1,12 @@
 import { RenderTree } from '@app/common/interfaces/crosswalk-connection.interface';
-import { Dropdown } from 'suomifi-ui-components';
-import { DropdownItem } from 'suomifi-ui-components';
+import { Dropdown, DropdownItem } from 'suomifi-ui-components';
 import { useState, useEffect } from 'react';
 import Box from '@mui/material/Box';
 import { InfoIcon } from '@app/common/components/shared-icons';
 
 export default function NodeInfo(props: {
   treeData: RenderTree[];
-  performNodeInfoAction: any;
+  // performNodeInfoAction: any;
 }) {
   let sourceSelectionInit = '';
 

--- a/mscr-ui/src/common/components/schema-info/schema-tree/schema-tree-renderer/index.tsx
+++ b/mscr-ui/src/common/components/schema-info/schema-tree/schema-tree-renderer/index.tsx
@@ -248,7 +248,7 @@ export function generateTreeFromJson(jsonInput: any) {
             children: renderedTree,
         }
         retTree.push(treeRoot);
-        console.log('renderedTree', renderedTree);
+        // console.log('renderedTree', renderedTree);
         resolve(retTree);
     });
 }

--- a/mscr-ui/src/common/interfaces/format.interface.ts
+++ b/mscr-ui/src/common/interfaces/format.interface.ts
@@ -19,5 +19,7 @@ export const formatsAvailableForCrosswalkCreation: Format[] = [
 ];
 
 export const formatsAvailableForCrosswalkRegistration: Format[] = [
-  Format.Xslt, Format.Csv, Format.Pdf,
+  Format.Xslt,
+  Format.Csv,
+  Format.Pdf,
 ];

--- a/mscr-ui/src/modules/crosswalk-editor/index.tsx
+++ b/mscr-ui/src/modules/crosswalk-editor/index.tsx
@@ -409,7 +409,7 @@ export default function CrosswalkEditor({
   };
 
   const performCallbackFromSchemaInfo = (
-    nodeIds: any,
+    nodeIds: RenderTree[],
     isSourceTree: boolean,
   ) => {
     if (nodeIds.length > 0) {

--- a/mscr-ui/src/modules/schema-view/index.tsx
+++ b/mscr-ui/src/modules/schema-view/index.tsx
@@ -86,7 +86,7 @@ export default function SchemaView({
             />
           )}
           {selectedTab === 1 && (
-            <SchemaVisualization pid={schemaId} />
+            <SchemaVisualization pid={schemaId} format={schemaDetails.format} />
           )}
           {selectedTab === 2 && (
             <VersionHistory

--- a/mscr-ui/src/modules/schema-view/index.tsx
+++ b/mscr-ui/src/modules/schema-view/index.tsx
@@ -8,6 +8,7 @@ import MetadataAndFiles from './metadata-and-files';
 import { createTheme, ThemeProvider } from '@mui/material';
 import { MscrUser } from '@app/common/interfaces/mscr-user.interface';
 import VersionHistory from 'src/common/components/version-history';
+import SchemaVisualization from '@app/modules/schema-view/schema-visualization';
 
 export default function SchemaView({
   schemaId,
@@ -73,7 +74,8 @@ export default function SchemaView({
               aria-label="Category selection"
             >
               <Tab label={t('tabs.metadata-and-files')} {...a11yProps(0)} />
-              <Tab label={t('tabs.version-history')} {...a11yProps(1)} />
+              <Tab label={t('tabs.schema')} {...a11yProps(1)} />
+              <Tab label={t('tabs.version-history')} {...a11yProps(2)} />
             </Tabs>
           </Box>
 
@@ -84,6 +86,9 @@ export default function SchemaView({
             />
           )}
           {selectedTab === 1 && (
+            <SchemaVisualization pid={schemaId} />
+          )}
+          {selectedTab === 2 && (
             <VersionHistory
               revisions={schemaDetails.revisions}
             />

--- a/mscr-ui/src/modules/schema-view/index.tsx
+++ b/mscr-ui/src/modules/schema-view/index.tsx
@@ -80,18 +80,13 @@ export default function SchemaView({
           </Box>
 
           {selectedTab === 0 && schemaDetails && (
-            <MetadataAndFiles
-              schemaDetails={schemaDetails}
-              refetch={refetch}
-            />
+            <MetadataAndFiles schemaDetails={schemaDetails} refetch={refetch} />
           )}
           {selectedTab === 1 && (
             <SchemaVisualization pid={schemaId} format={schemaDetails.format} />
           )}
           {selectedTab === 2 && (
-            <VersionHistory
-              revisions={schemaDetails.revisions}
-            />
+            <VersionHistory revisions={schemaDetails.revisions} />
           )}
         </>
       </ThemeProvider>

--- a/mscr-ui/src/modules/schema-view/schema-visualization/index.tsx
+++ b/mscr-ui/src/modules/schema-view/schema-visualization/index.tsx
@@ -1,0 +1,10 @@
+import SchemaInfo from '@app/common/components/schema-info';
+import { useTranslation } from 'next-i18next';
+
+export default function SchemaVisualization({pid}: {pid: string}) {
+  const { t } = useTranslation('common');
+  const filterLabel = t('schema-tree.filter-schema');
+  return (
+    <SchemaInfo caption={filterLabel} schemaUrn={pid} />
+  );
+}

--- a/mscr-ui/src/modules/schema-view/schema-visualization/index.tsx
+++ b/mscr-ui/src/modules/schema-view/schema-visualization/index.tsx
@@ -4,6 +4,7 @@ import {
   Format,
   formatsAvailableForCrosswalkCreation,
 } from '@app/common/interfaces/format.interface';
+import { SchemaVisualizationContainer } from '@app/modules/schema-view/schema-visualization/schema-visualization.styles';
 
 export default function SchemaVisualization({
   pid,
@@ -17,7 +18,11 @@ export default function SchemaVisualization({
   const visualizationAvailable =
     formatsAvailableForCrosswalkCreation.includes(format);
   if (visualizationAvailable) {
-    return <SchemaInfo caption={filterLabel} schemaUrn={pid} />;
+    return (
+      <SchemaVisualizationContainer>
+        <SchemaInfo caption={filterLabel} schemaUrn={pid} />
+      </SchemaVisualizationContainer>
+    );
   } else {
     return (
       <>

--- a/mscr-ui/src/modules/schema-view/schema-visualization/index.tsx
+++ b/mscr-ui/src/modules/schema-view/schema-visualization/index.tsx
@@ -1,15 +1,23 @@
 import SchemaInfo from '@app/common/components/schema-info';
 import { useTranslation } from 'next-i18next';
-import { Format, formatsAvailableForCrosswalkCreation } from '@app/common/interfaces/format.interface';
+import {
+  Format,
+  formatsAvailableForCrosswalkCreation,
+} from '@app/common/interfaces/format.interface';
 
-export default function SchemaVisualization({pid, format}: {pid: string; format: Format}) {
+export default function SchemaVisualization({
+  pid,
+  format,
+}: {
+  pid: string;
+  format: Format;
+}) {
   const { t } = useTranslation('common');
   const filterLabel = t('schema-tree.filter-schema');
-  const visualizationAvailable = formatsAvailableForCrosswalkCreation.includes(format);
+  const visualizationAvailable =
+    formatsAvailableForCrosswalkCreation.includes(format);
   if (visualizationAvailable) {
-    return (
-      <SchemaInfo caption={filterLabel} schemaUrn={pid} />
-    );
+    return <SchemaInfo caption={filterLabel} schemaUrn={pid} />;
   } else {
     return (
       <>
@@ -18,5 +26,4 @@ export default function SchemaVisualization({pid, format}: {pid: string; format:
       </>
     );
   }
-
 }

--- a/mscr-ui/src/modules/schema-view/schema-visualization/index.tsx
+++ b/mscr-ui/src/modules/schema-view/schema-visualization/index.tsx
@@ -1,10 +1,22 @@
 import SchemaInfo from '@app/common/components/schema-info';
 import { useTranslation } from 'next-i18next';
+import { Format, formatsAvailableForCrosswalkCreation } from '@app/common/interfaces/format.interface';
 
-export default function SchemaVisualization({pid}: {pid: string}) {
+export default function SchemaVisualization({pid, format}: {pid: string; format: Format}) {
   const { t } = useTranslation('common');
   const filterLabel = t('schema-tree.filter-schema');
-  return (
-    <SchemaInfo caption={filterLabel} schemaUrn={pid} />
-  );
+  const visualizationAvailable = formatsAvailableForCrosswalkCreation.includes(format);
+  if (visualizationAvailable) {
+    return (
+      <SchemaInfo caption={filterLabel} schemaUrn={pid} />
+    );
+  } else {
+    return (
+      <>
+        <h2>{t('schema-tree.error-heading')}</h2>
+        <p>{t('schema-tree.error-info')}</p>
+      </>
+    );
+  }
+
 }

--- a/mscr-ui/src/modules/schema-view/schema-visualization/schema-visualization.styles.tsx
+++ b/mscr-ui/src/modules/schema-view/schema-visualization/schema-visualization.styles.tsx
@@ -3,7 +3,4 @@ import styled from 'styled-components';
 export const SchemaVisualizationContainer = styled.div`
   max-width: 1200px;
   background-color: white;
-  .MuiTreeItem-content {
-    max-width: 100px;
-  }
 `;

--- a/mscr-ui/src/modules/schema-view/schema-visualization/schema-visualization.styles.tsx
+++ b/mscr-ui/src/modules/schema-view/schema-visualization/schema-visualization.styles.tsx
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+export const SchemaVisualizationContainer = styled.div`
+  max-width: 1200px;
+  background-color: white;
+  .MuiTreeItem-content {
+    max-width: 100px;
+  }
+`;

--- a/mscr-ui/src/pages/mscr-style-customizations.scss
+++ b/mscr-ui/src/pages/mscr-style-customizations.scss
@@ -87,14 +87,6 @@ body {
 
 .crosswalk-editor {
   color: #2b2b2b;
-  .fi-dropdown_button {
-    min-width: 100% !important;
-    width: 100%;
-  }
-
-  .fi-search-input {
-    width: 100%;
-  }
 
   h2 {
     color: #6b6b6b;
@@ -102,63 +94,11 @@ body {
     font-weight: bold;
   }
 
-  .expand-button-wrap {
-    margin-top: 37px;
-    margin-right: 15px;
-  }
-
   .link-button {
     width: 60px;
     height: 60px;
     svg {
       margin-left: -2px;
-    }
-  }
-
-  .node-info-wrap {
-    font-size: 0.9rem;
-    color: #6b6b6b;
-    .attribute-font {
-      font-size: 0.9rem;
-      line-height: 1.3rem;
-      margin-bottom: 2px;
-      color: #2b2b2b;
-      margin-top: -2px;
-      inline-size: 100%;
-      overflow-wrap: break-word;
-    }
-    h2 {
-      color: #6b6b6b;
-      font-size: 1.1rem;
-      font-weight: normal;
-      margin-bottom: 0px;
-      padding: 17px 14px 0px 17px;
-    }
-    .fi-dropdown {
-      width: 100%;
-    }
-    .side-bar-wrap {
-      padding: 5px 5px;
-    }
-    background: #d8e3f4;
-    .dropdown-wrap {
-      margin-top: -5px;
-      margin-bottom: 15px;
-    }
-    .bg-wrap {
-      font-size: 0.95rem;
-      background: #fff;
-      padding: 15px;
-      min-height: 377px;
-      max-width: 500px;
-    }
-    .node-info-texts {
-      padding: 5px;
-    }
-    .node-info-dropdown {
-      ul {
-        max-width: 265px !important;
-      }
     }
   }
 
@@ -226,25 +166,6 @@ body {
     //border: 4px solid #3D6DB6;
     background-color: #fff;
     border-radius: 5px;
-  }
-
-  .node-info-box {
-    min-height: 175px;
-    font-size: 0.95rem;
-    margin: 0px;
-
-    .source-to-destination-wrap {
-      min-height: 42px;
-
-      button {
-        padding: 0px;
-      }
-
-      .arrow-icon {
-        margin: 0px 15px;
-        font-size: 1.3rem;
-      }
-    }
   }
 
   h5 {

--- a/mscr-ui/src/pages/mscr-style-customizations.scss
+++ b/mscr-ui/src/pages/mscr-style-customizations.scss
@@ -142,7 +142,7 @@ body {
     }
     background: #d8e3f4;
     .dropdown-wrap {
-      margin-top: -35px;
+      margin-top: -5px;
       margin-bottom: 15px;
     }
     .bg-wrap {


### PR DESCRIPTION
Only styles are missing. Many styles for the schema info come from mscr-style-customizations.scss where the parent class is expected to be .crosswalk-editor, which it no longer exclusively is. I'll try to convert those styles to styled-components to be more congruent with our other code, and so that the component is truly reusable.