### PR TITLE
CSCFC4EMSCR-430 Show owner in content metadata tab

### DIFF
--- a/mscr-ui/public/locales/en/common.json
+++ b/mscr-ui/public/locales/en/common.json
@@ -121,6 +121,7 @@
     "format": "Format",
     "modified": "Modified",
     "name": "Name",
+    "owner": "Owner",
     "pid": "PID",
     "schema-details": "Schema details",
     "state": "State",

--- a/mscr-ui/public/locales/fi/common.json
+++ b/mscr-ui/public/locales/fi/common.json
@@ -121,6 +121,7 @@
     "format": "",
     "modified": "",
     "name": "",
+    "owner": "",
     "pid": "",
     "schema-details": "",
     "state": "",

--- a/mscr-ui/public/locales/sv/common.json
+++ b/mscr-ui/public/locales/sv/common.json
@@ -121,6 +121,7 @@
     "format": "",
     "modified": "",
     "name": "",
+    "owner": "",
     "pid": "",
     "schema-details": "",
     "state": "",

--- a/mscr-ui/src/common/interfaces/metadata.interface.ts
+++ b/mscr-ui/src/common/interfaces/metadata.interface.ts
@@ -17,6 +17,10 @@ export interface Metadata {
   modified: string;
   versionLabel: string;
   contact: string;
+  ownerMetadata: [{
+    id: string;
+    name: string;
+  }];
   sourceSchema?: string;
   targetSchema?: string;
   namespace?: string;

--- a/mscr-ui/src/modules/form/metadata-form/index.tsx
+++ b/mscr-ui/src/modules/form/metadata-form/index.tsx
@@ -248,6 +248,15 @@ export default function MetadataForm({
 
               <Grid container className="basic-row">
                 <Grid item xs={4} className="br-heading">
+                  {t('metadata.owner')}:
+                </Grid>
+                <Grid item xs={8}>
+                  <div className="br-label">{metadata.ownerMetadata.map((o) => o.name ?? o.id).toString()}</div>
+                </Grid>
+              </Grid>
+
+              <Grid container className="basic-row">
+                <Grid item xs={4} className="br-heading">
                   {t('metadata.pid')}:
                 </Grid>
                 <Grid item xs={8}>

--- a/mscr-ui/src/modules/form/metadata-form/index.tsx
+++ b/mscr-ui/src/modules/form/metadata-form/index.tsx
@@ -251,7 +251,7 @@ export default function MetadataForm({
                   {t('metadata.owner')}:
                 </Grid>
                 <Grid item xs={8}>
-                  <div className="br-label">{metadata.ownerMetadata.map((o) => o.name ?? o.id).toString()}</div>
+                  <div className="br-label">{metadata.ownerMetadata.map((o) => o.name ?? o.id).join(', ')}</div>
                 </Grid>
               </Grid>
 


### PR DESCRIPTION
A list of names is shown, or if no name is present, the id is shown

Locally the owner metadata doesn't include a name for the Admin user we impersonate as. Will need to see whether that happens in rahti environment, and make a backend ticket if needed.