### PR TITLE
CSCFC4EMSCR-520 Refactor schema tree to improve selecting performance

### DIFF
--- a/mscr-ui/public/locales/en/common.json
+++ b/mscr-ui/public/locales/en/common.json
@@ -300,6 +300,7 @@
     "search-placeholder": "Find an attribute...",
     "search-schema": "Search from schema",
     "selected-node": "Selected node:",
+    "show-titles": "Show node titles",
     "tree-label": "Schema tree"
   },
   "search": {

--- a/mscr-ui/public/locales/fi/common.json
+++ b/mscr-ui/public/locales/fi/common.json
@@ -300,6 +300,7 @@
     "search-placeholder": "",
     "search-schema": "",
     "selected-node": "",
+    "show-titles": "",
     "tree-label": ""
   },
   "search": {

--- a/mscr-ui/public/locales/sv/common.json
+++ b/mscr-ui/public/locales/sv/common.json
@@ -300,6 +300,7 @@
     "search-placeholder": "",
     "search-schema": "",
     "selected-node": "",
+    "show-titles": "",
     "tree-label": ""
   },
   "search": {

--- a/mscr-ui/src/common/components/schema-info/schema-tree/index.tsx
+++ b/mscr-ui/src/common/components/schema-info/schema-tree/index.tsx
@@ -12,7 +12,7 @@ function toTree(nodes: RenderTree, showQname: boolean) {
     return nodes.map((node) => {
       return (
         <TreeItem
-          key={node.id}
+          key={node.visualTreeId}
           nodeId={node.id}
           label={showQname ? node.qname : node.name}
           className="linked-tree-item"
@@ -26,7 +26,7 @@ function toTree(nodes: RenderTree, showQname: boolean) {
   } else {
     ret = (
       <TreeItem
-        key={nodes.id}
+        key={nodes.visualTreeId}
         nodeId={nodes.id}
         label={showQname ? nodes.qname : nodes.name}
         className="linked-tree-item"
@@ -75,7 +75,7 @@ export default function SchemaTree({
       multiSelect
     >
       <TreeItem
-        key={nodes.id}
+        key={nodes.visualTreeId}
         nodeId={nodes.id}
         label={nodes.name}
         className="linked-tree-item"

--- a/mscr-ui/src/common/components/schema-info/schema-tree/node-info/index.tsx
+++ b/mscr-ui/src/common/components/schema-info/schema-tree/node-info/index.tsx
@@ -1,5 +1,5 @@
 import { RenderTree } from '@app/common/interfaces/crosswalk-connection.interface';
-import { Dropdown, DropdownItem } from 'suomifi-ui-components';
+import { Dropdown, DropdownItem, ToggleButton } from 'suomifi-ui-components';
 import { useState, useEffect } from 'react';
 import Box from '@mui/material/Box';
 import { InfoIcon } from '@app/common/components/shared-icons';
@@ -8,46 +8,35 @@ import { DropdownWrapper } from '@app/common/components/schema-info/schema-info.
 
 export default function NodeInfo(props: {
   treeData: RenderTree[];
-  dataIsLoaded: boolean
+  dataIsLoaded: boolean;
   // performNodeInfoAction: any;
 }) {
   const { t } = useTranslation('common');
-  let sourceSelectionInit = '';
+  const [selectedNode, setSelectedNode] = useState<RenderTree>();
+  const [dropDownList, setDropDownList] = useState<RenderTree[]>([]);
 
   useEffect(() => {
     if (props.treeData && props.treeData.length > 0) {
-      sourceSelectionInit = props.treeData[0].id;
-      setDropdownValue(props.treeData[0].id);
-      // console.log('props.sourceData');
+      setDropDownList(props.treeData);
+      setSelectedNode(props.treeData[0]);
+    } else {
+      setSelectedNode(undefined);
     }
-    if (props.dataIsLoaded) {
-      setDataIsLoaded(true);
-    }
-  }, [props]);
+  }, [props.treeData]);
 
-  const [dataIsLoaded, setDataIsLoaded] = useState(false);
-  const [sourceDropdownValue, setDropdownValue] = useState(sourceSelectionInit);
-  const [selectedNode] = props.treeData.filter(
-    (item) => item.id === sourceDropdownValue
-  );
+  const handleDropDownSelect = (nodeId: string) => {
+    const newSelectedNode = props.treeData.find((item) => item.id === nodeId);
+    setSelectedNode(newSelectedNode ?? selectedNode);
+  };
 
-  let dropdownInit: { id: string; name?: string }[] = [
-    {
-      id: '1',
-    },
-  ];
-  if (props.treeData && props.treeData.length > 0) {
-    dropdownInit = props.treeData;
-  }
-
-  interface constantAttribute {
+  interface ConstantAttribute {
     name: string;
     value: string | undefined;
   }
 
-  const nodeProperties: constantAttribute[] = [];
-  if (props.treeData.length > 0 && props.treeData[0]?.properties) {
-    for (const [key, value] of Object.entries(props.treeData[0]?.properties)) {
+  const nodeProperties: ConstantAttribute[] = [];
+  if (selectedNode && selectedNode.properties) {
+    for (const [key, value] of Object.entries(selectedNode.properties)) {
       nodeProperties.push({
         name: key,
         value: typeof value === 'string' ? value.toString() : undefined,
@@ -89,32 +78,26 @@ export default function NodeInfo(props: {
                   </div>
                 </div>
                 <div className="col-10 d-flex align-self-center">
-                  {!dataIsLoaded &&
-                      <div>
-                        {t('node-info.loading')}
-                      </div>
-                  }
-                  {dataIsLoaded &&
-                      <div>
-                        {t('node-info.select-a-node')}
-                      </div>
-                  }
+                  {!props.dataIsLoaded && <div>{t('node-info.loading')}</div>}
+                  {props.dataIsLoaded && (
+                    <div>{t('node-info.select-a-node')}</div>
+                  )}
                 </div>
               </div>
             </>
           )}
-          {props.treeData.length > 1 && (
+          {dropDownList.length > 1 && (
             <DropdownWrapper>
               <Dropdown
                 labelText={t('schema-tree.dropdown-label')}
                 labelMode={'hidden'}
                 className="mt-2"
                 visualPlaceholder={t('schema-tree.dropdown-placeholder')}
-                value={sourceDropdownValue}
-                onChange={(newValue) => setDropdownValue(newValue)}
+                value={selectedNode?.id ?? ''}
+                onChange={(newValue) => handleDropDownSelect(newValue)}
               >
-                {dropdownInit.map((rt) => (
-                  <DropdownItem key={rt.id} value={rt.id}>
+                {dropDownList.map((rt) => (
+                  <DropdownItem key={rt.visualTreeId} value={rt.id}>
                     {rt.name}
                   </DropdownItem>
                 ))}

--- a/mscr-ui/src/common/components/schema-info/schema-tree/schema-tree-renderer/index.tsx
+++ b/mscr-ui/src/common/components/schema-info/schema-tree/schema-tree-renderer/index.tsx
@@ -1,257 +1,281 @@
-import {cloneDeep} from "lodash";
-import {RenderTree, RenderTreeOld} from "@app/common/interfaces/crosswalk-connection.interface";
+import {RenderTree, RenderTreeOld} from '@app/common/interfaces/crosswalk-connection.interface';
 
-export default function MockupSchemaLoader(emptyTemplate: boolean): Promise<RenderTree[] | undefined> {
+// export default function MockupSchemaLoader(emptyTemplate: boolean): Promise<RenderTree[] | undefined> {
+//
+//     let allTreeNodes: RenderTreeOld[] = [];
+//
+//     let currentTreeNode: RenderTreeOld = {
+//         idNumeric: 0,
+//         id: '0',
+//         name: '',
+//         isLinked: false,
+//         title: '',
+//         type: '',
+//         description: '',
+//         required: '',
+//         isMappable: '',
+//         parentName: '',
+//         jsonPath: '$schema',
+//         parentId: 0,
+//         children: []
+//     };
+//
+//     let nodeId = 0;
+//
+//     function increaseNodeNumber() {
+//         nodeId += 1;
+//     }
+//
+//     function createTreeObject(object: string, value: string, parent: string, rootId: any, jsonPath: string) {
+//         currentTreeNode.jsonPath = jsonPath + '.' + object;
+//         currentTreeNode.idNumeric = nodeId;
+//         currentTreeNode.id = nodeId.toString();
+//         currentTreeNode.parentId = rootId;
+//         currentTreeNode.name = object;
+//         currentTreeNode.title = value;
+//         currentTreeNode.parentName = parent;
+//         increaseNodeNumber();
+//     }
+//
+//     function walkJson(json_object: any, parent: any, rootId: number, jsonPath: string) {
+//         for (const obj in json_object) {
+//             if (typeof json_object[obj] === 'string') {
+//                 //console.log(`leaf ${obj} = ${json_object[obj]}`);
+//
+//                 // OBJECT IS A LEAF LEVEL OBJECT
+//                 currentTreeNode = {
+//                     isLinked: false,
+//                     idNumeric: 0,
+//                     id: '0',
+//                     name: '',
+//                     title: '',
+//                     type: 'string',
+//                     description: '',
+//                     required: '',
+//                     parentId: 0,
+//                     jsonPath,
+//                     children: []
+//                 };
+//                 createTreeObject(obj, json_object[obj], parent, rootId, jsonPath);
+//                 allTreeNodes.push(cloneDeep(currentTreeNode));
+//             } else {
+//                 // OBJECT HAS CHILDREN
+//                 currentTreeNode = {
+//                     isLinked: false,
+//                     idNumeric: 0,
+//                     id: '0',
+//                     name: '',
+//                     title: '',
+//                     type: Array.isArray(json_object[obj]) ? 'array' : 'composite',
+//                     description: '',
+//                     required: '',
+//                     parentId: 0,
+//                     jsonPath,
+//                     children: []
+//                 };
+//                 currentTreeNode.name = obj;
+//                 currentTreeNode.parentName = parent;
+//                 currentTreeNode.parentId = rootId;
+//                 currentTreeNode.idNumeric = nodeId;
+//                 currentTreeNode.id = nodeId.toString();
+//
+//
+//                 currentTreeNode.jsonPath = jsonPath + '.' + obj;
+//                 increaseNodeNumber();
+//                 allTreeNodes.push(cloneDeep(currentTreeNode));
+//                 walkJson(json_object[obj], obj, nodeId - 1, currentTreeNode.jsonPath);
+//             }
+//         }
+//         return allTreeNodes;
+//     }
+//
+//
+//     function walkJsonOld(json_object: any, parent: any, rootId: number, jsonPath: string) {
+//         for (const obj in json_object) {
+//             if (typeof json_object[obj] === 'string') {
+//                 //console.log(`leaf ${obj} = ${json_object[obj]}`);
+//
+//                 // OBJECT IS A LEAF LEVEL OBJECT
+//                 currentTreeNode = {
+//                     isLinked: false,
+//                     idNumeric: 0,
+//                     id: '0',
+//                     name: '',
+//                     title: '',
+//                     type: 'string',
+//                     description: '',
+//                     required: '',
+//                     parentId: 0,
+//                     jsonPath,
+//                     children: []
+//                 };
+//                 createTreeObject(obj, json_object[obj], parent, rootId, jsonPath);
+//                 allTreeNodes.push(cloneDeep(currentTreeNode));
+//             } else if (typeof json_object[obj] === 'boolean') {
+//                 //console.log('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! FOUND BOOLEAN', obj, json_object[obj], json_object);
+//
+//                 // OBJECT IS A LEAF LEVEL OBJECT
+//                 currentTreeNode = {
+//                     isLinked: false,
+//                     idNumeric: 0,
+//                     id: '0',
+//                     name: '',
+//                     title: '',
+//                     type: json_object[obj].toString(),
+//                     description: '',
+//                     required: '',
+//                     parentId: 0,
+//                     jsonPath,
+//                     children: []
+//                 };
+//                 createTreeObject(obj, json_object[obj], parent, rootId, jsonPath);
+//                 allTreeNodes.push(cloneDeep(currentTreeNode));
+//             } else {
+//                 // OBJECT HAS CHILDREN
+//                 currentTreeNode = {
+//                     isLinked: false,
+//                     idNumeric: 0,
+//                     id: '0',
+//                     name: '',
+//                     title: '',
+//                     type: Array.isArray(json_object[obj]) ? 'array' : 'composite',
+//                     description: '',
+//                     required: '',
+//                     parentId: 0,
+//                     jsonPath,
+//                     children: []
+//                 };
+//                 currentTreeNode.name = obj;
+//                 currentTreeNode.parentName = parent;
+//                 currentTreeNode.parentId = rootId;
+//                 currentTreeNode.idNumeric = nodeId;
+//                 currentTreeNode.id = nodeId.toString();
+//
+//
+//                 currentTreeNode.jsonPath = jsonPath + '.' + obj;
+//                 increaseNodeNumber();
+//                 allTreeNodes.push(cloneDeep(currentTreeNode));
+//                 walkJsonOld(json_object[obj], obj, nodeId - 1, currentTreeNode.jsonPath);
+//             }
+//         }
+//         return allTreeNodes;
+//     }
+//
+//     function mergeAttributesToParent(inputNodes: RenderTreeOld[] | undefined) {
+//         if (inputNodes) {
+//             let outputNodes = inputNodes.map((parent: RenderTreeOld) => {
+//                     if (parent.children) {
+//                         let i = parent.children.length;
+//                         while (i--) {
+//                             // @ts-ignore
+//                             if (parent.children[i] && parent.children[i].children.length > 0) {
+//                                 mergeAttributesToParent([parent.children[i]]);
+//                             }
+//                             if (parent.children[i].name === 'type') {
+//                                 parent.type = parent.children[i].title;
+//                                 //parent.children.splice(i, 1);
+//                             } else if (parent.children[i].name === 'description') {
+//                                 parent.description = parent.children[i].title;
+//                                 //parent.children.splice(i, 1);
+//                             } else if (parent.children[i].name === 'title') {
+//                                 parent.title = parent.children[i].title;
+//                                 //parent.children.splice(i, 1);
+//                             }
+//                         }
+//                     }
+//                     return parent;
+//                 }
+//             );
+//             return outputNodes;
+//         }
+//     }
+//
+//     // Unused
+//     function reverseTreeChildren(inputNodes: RenderTreeOld[] | undefined) {
+//         if (inputNodes) {
+//             for (let i = 0; i < inputNodes.length; i += 1) {
+//                 // @ts-ignore
+//                 if (inputNodes[i].children.length > 1) {
+//                     // @ts-ignore
+//                     inputNodes[i].children = inputNodes[i].children.reverse()
+//                     reverseTreeChildren(inputNodes[i].children);
+//                 }
+//             }
+//             return inputNodes;
+//         }
+//     }
+// }
 
-    let allTreeNodes: RenderTreeOld[] = [];
 
-    let currentTreeNode: RenderTreeOld = {
-        idNumeric: 0,
-        id: '0',
-        name: '',
-        isLinked: false,
-        title: '',
-        type: '',
-        description: '',
-        required: '',
-        isMappable: '',
-        parentName: '',
-        jsonPath: '$schema',
-        parentId: 0,
-        children: []
-    };
-
-    let nodeId = 0;
-
-    function increaseNodeNumber() {
-        nodeId += 1;
-    }
-
-    function createTreeObject(object: string, value: string, parent: string, rootId: any, jsonPath: string) {
-        currentTreeNode.jsonPath = jsonPath + '.' + object;
-        currentTreeNode.idNumeric = nodeId;
-        currentTreeNode.id = nodeId.toString();
-        currentTreeNode.parentId = rootId;
-        currentTreeNode.name = object;
-        currentTreeNode.title = value;
-        currentTreeNode.parentName = parent;
-        increaseNodeNumber();
-    }
-
-    function walkJson(json_object: any, parent: any, rootId: number, jsonPath: string) {
-        for (const obj in json_object) {
-            if (typeof json_object[obj] === 'string') {
-                //console.log(`leaf ${obj} = ${json_object[obj]}`);
-
-                // OBJECT IS A LEAF LEVEL OBJECT
-                currentTreeNode = {
-                    isLinked: false,
-                    idNumeric: 0,
-                    id: '0',
-                    name: '',
-                    title: '',
-                    type: 'string',
-                    description: '',
-                    required: '',
-                    parentId: 0,
-                    jsonPath,
-                    children: []
-                };
-                createTreeObject(obj, json_object[obj], parent, rootId, jsonPath);
-                allTreeNodes.push(cloneDeep(currentTreeNode));
-            } else {
-                // OBJECT HAS CHILDREN
-                currentTreeNode = {
-                    isLinked: false,
-                    idNumeric: 0,
-                    id: '0',
-                    name: '',
-                    title: '',
-                    type: Array.isArray(json_object[obj]) ? 'array' : 'composite',
-                    description: '',
-                    required: '',
-                    parentId: 0,
-                    jsonPath,
-                    children: []
-                };
-                currentTreeNode.name = obj;
-                currentTreeNode.parentName = parent;
-                currentTreeNode.parentId = rootId;
-                currentTreeNode.idNumeric = nodeId;
-                currentTreeNode.id = nodeId.toString();
-
-
-                currentTreeNode.jsonPath = jsonPath + '.' + obj;
-                increaseNodeNumber();
-                allTreeNodes.push(cloneDeep(currentTreeNode));
-                walkJson(json_object[obj], obj, nodeId - 1, currentTreeNode.jsonPath);
-            }
-        }
-        return allTreeNodes;
-    }
-
-
-    function walkJsonOld(json_object: any, parent: any, rootId: number, jsonPath: string) {
-        for (const obj in json_object) {
-            if (typeof json_object[obj] === 'string') {
-                //console.log(`leaf ${obj} = ${json_object[obj]}`);
-
-                // OBJECT IS A LEAF LEVEL OBJECT
-                currentTreeNode = {
-                    isLinked: false,
-                    idNumeric: 0,
-                    id: '0',
-                    name: '',
-                    title: '',
-                    type: 'string',
-                    description: '',
-                    required: '',
-                    parentId: 0,
-                    jsonPath,
-                    children: []
-                };
-                createTreeObject(obj, json_object[obj], parent, rootId, jsonPath);
-                allTreeNodes.push(cloneDeep(currentTreeNode));
-            } else if (typeof json_object[obj] === 'boolean') {
-                //console.log('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! FOUND BOOLEAN', obj, json_object[obj], json_object);
-
-                // OBJECT IS A LEAF LEVEL OBJECT
-                currentTreeNode = {
-                    isLinked: false,
-                    idNumeric: 0,
-                    id: '0',
-                    name: '',
-                    title: '',
-                    type: json_object[obj].toString(),
-                    description: '',
-                    required: '',
-                    parentId: 0,
-                    jsonPath,
-                    children: []
-                };
-                createTreeObject(obj, json_object[obj], parent, rootId, jsonPath);
-                allTreeNodes.push(cloneDeep(currentTreeNode));
-            } else {
-                // OBJECT HAS CHILDREN
-                currentTreeNode = {
-                    isLinked: false,
-                    idNumeric: 0,
-                    id: '0',
-                    name: '',
-                    title: '',
-                    type: Array.isArray(json_object[obj]) ? 'array' : 'composite',
-                    description: '',
-                    required: '',
-                    parentId: 0,
-                    jsonPath,
-                    children: []
-                };
-                currentTreeNode.name = obj;
-                currentTreeNode.parentName = parent;
-                currentTreeNode.parentId = rootId;
-                currentTreeNode.idNumeric = nodeId;
-                currentTreeNode.id = nodeId.toString();
-
-
-                currentTreeNode.jsonPath = jsonPath + '.' + obj;
-                increaseNodeNumber();
-                allTreeNodes.push(cloneDeep(currentTreeNode));
-                walkJsonOld(json_object[obj], obj, nodeId - 1, currentTreeNode.jsonPath);
-            }
-        }
-        return allTreeNodes;
-    }
-
-    function mergeAttributesToParent(inputNodes: RenderTreeOld[] | undefined) {
-        if (inputNodes) {
-            let outputNodes = inputNodes.map((parent: RenderTreeOld) => {
-                    if (parent.children) {
-                        let i = parent.children.length;
-                        while (i--) {
-                            // @ts-ignore
-                            if (parent.children[i] && parent.children[i].children.length > 0) {
-                                mergeAttributesToParent([parent.children[i]]);
-                            }
-                            if (parent.children[i].name === 'type') {
-                                parent.type = parent.children[i].title;
-                                //parent.children.splice(i, 1);
-                            } else if (parent.children[i].name === 'description') {
-                                parent.description = parent.children[i].title;
-                                //parent.children.splice(i, 1);
-                            } else if (parent.children[i].name === 'title') {
-                                parent.title = parent.children[i].title;
-                                //parent.children.splice(i, 1);
-                            }
-                        }
-                    }
-                    return parent;
-                }
-            );
-            return outputNodes;
-        }
-    }
-
-    // Unused
-    function reverseTreeChildren(inputNodes: RenderTreeOld[] | undefined) {
-        if (inputNodes) {
-            for (let i = 0; i < inputNodes.length; i += 1) {
-                // @ts-ignore
-                if (inputNodes[i].children.length > 1) {
-                    // @ts-ignore
-                    inputNodes[i].children = inputNodes[i].children.reverse()
-                    reverseTreeChildren(inputNodes[i].children);
-                }
-            }
-            return inputNodes;
-        }
-    }
-}
 let treeIndex = 0;
 
-function createRenderTree(input: any, elementPath: string, definitions: any) {
-    let retArray: RenderTree[] = [];
-    for (let obj in input) {
-        treeIndex += 1;
-        let newNode: RenderTree = {
-            name: definitions[obj].title,
-            qname: definitions[obj]?.qname ? definitions[obj]?.qname : 'empty',
-            visualTreeId: treeIndex.toString(),
-            id: obj.toString(),
-            properties: definitions[obj],
-            elementPath: elementPath + '.' + obj.toString(),
-            parentElementPath: elementPath,
-            children: [],
-            uri: definitions[obj]['@id']
-        };
+function createRenderTree(
+  input: any,
+  elementPath: string,
+  definitions: any,
+  idToNodeDictionary: { [key: string]: RenderTree[] },
+) {
+  const retArray: RenderTree[] = [];
+  for (const obj in input) {
+    treeIndex += 1;
+    const newNode: RenderTree = {
+      name: definitions[obj].title,
+      qname: definitions[obj]?.qname ? definitions[obj]?.qname : 'empty',
+      visualTreeId: treeIndex.toString(),
+      id: obj.toString(),
+      properties: definitions[obj],
+      elementPath: elementPath + '.' + obj.toString(),
+      parentElementPath: elementPath,
+      children: [],
+      uri: definitions[obj]['@id'],
+    };
+    idToNodeDictionary[newNode.id] = idToNodeDictionary[newNode.id] ?? [];
+    idToNodeDictionary[newNode.id].push(newNode);
 
-        //console.log('OBJ', obj, input[obj].keys, Object.keys(input[obj]));
-        if (Object.keys(input[obj]).length > 0) {
-            // HAS CHILDREN
-            newNode.children = createRenderTree(input[obj], newNode.elementPath, definitions);
-        } else {
-            // IS LEAF
-        }
-        retArray.push(newNode);
+    //console.log('OBJ', obj, input[obj].keys, Object.keys(input[obj]));
+    if (Object.keys(input[obj]).length > 0) {
+      // HAS CHILDREN
+      newNode.children = createRenderTree(
+        input[obj],
+        newNode.elementPath,
+        definitions,
+        idToNodeDictionary,
+      );
+    } else {
+      // IS LEAF
     }
-    return retArray;
+    retArray.push(newNode);
+  }
+  return retArray;
 }
 
 export function generateTreeFromJson(jsonInput: any) {
-    return new Promise<RenderTree[]>((resolve) => {
-        let renderedTree = createRenderTree(jsonInput.content.tree, 'ROOT', jsonInput.content.definitions);
-        let retTree: RenderTree[] = [];
-        let treeRoot = {
-            name: 'ROOT',
-            qname: 'ROOT',
-            visualTreeId: '0',
-            id: 'ROOT',
-            properties: undefined,
-            elementPath: 'ROOT',
-            parentElementPath: undefined,
-            children: renderedTree,
-        }
-        retTree.push(treeRoot);
-        // console.log('renderedTree', renderedTree);
-        resolve(retTree);
+  const nodeIdToShallowNode: { [key: string]: RenderTree[] } = {};
+  const treeRoot: RenderTree = {
+    name: 'ROOT',
+    qname: 'ROOT',
+    visualTreeId: '0',
+    id: 'ROOT',
+    properties: undefined,
+    uri: '',
+    elementPath: 'ROOT',
+    parentElementPath: undefined,
+    children: [],
+  };
+  nodeIdToShallowNode['ROOT'] = [treeRoot];
+
+  const generatedTree = new Promise<RenderTree[]>((resolve) => {
+    const renderedTree = createRenderTree(
+      jsonInput.content.tree,
+      'ROOT',
+      jsonInput.content.definitions,
+      nodeIdToShallowNode
+    );
+    const retTree: RenderTree[] = [];
+    treeRoot.children = renderedTree;
+    retTree.push(treeRoot);
+    // console.log('renderedTree', renderedTree);
+    resolve(retTree);
     });
+  return {generatedTree, nodeIdToShallowNode};
 }


### PR DESCRIPTION
The implementation still shows multiple items selected when you select an attribute that has an identical id with another node in the tree. This makes sense if the mapping actions are based on id's and thus all with the same id are affected. Might need investigation and fixing if this is not corrected.  But the dropdown doesn't break, and you can see both of the selected nodes expanded.

Did some cleaning and simplifying of the code.