### PR TITLE
CSCFC4EMSCR-397 Minimized side navigation

### DIFF
--- a/mscr-ui/src/common/components/actionmenu/actionmenu.slice.tsx
+++ b/mscr-ui/src/common/components/actionmenu/actionmenu.slice.tsx
@@ -38,7 +38,7 @@ export interface FormState {
 
 const initialFormState: FormState = {
   mscrCopy: false,
-  version: false
+  version: false,
 };
 
 export interface ConfirmState {
@@ -65,8 +65,6 @@ const initialModalList: ModalList = {
 };
 
 const initialState = {
-  isLatest: false,
-  isPublished: false,
   isCrosswalk: false,
   menuList: initialMenuList,
   modal: initialModalList,
@@ -76,39 +74,29 @@ export const actionmenuSlice = createSlice({
   name: 'actionmenu',
   initialState: initialState,
   reducers: {
-    setIsLatest(state, action) {
-      return {
-        ...state,
-        isLatest: action.payload
-      };
-    },
-    setIsPublished(state, action) {
-      return {
-        ...state,
-        isPublished: action.payload
-      };
-    },
     setIsCrosswalk(state, action) {
       return {
         ...state,
-        isCrosswalk: action.payload
+        isCrosswalk: action.payload,
       };
     },
     setMenuList(state, action) {
       const menuListAddition: Partial<MenuList> = {};
-      action.payload.forEach((key: keyof MenuList) => menuListAddition[key] = true);
+      action.payload.forEach(
+        (key: keyof MenuList) => (menuListAddition[key] = true)
+      );
       return {
         ...state,
         menuList: {
           ...state.menuList,
-          ...menuListAddition
-        }
+          ...menuListAddition,
+        },
       };
     },
     setMenuListFull(state, action) {
       return {
         ...state,
-        menuList: action.payload
+        menuList: action.payload,
       };
     },
     setFormState(state, action) {
@@ -118,9 +106,9 @@ export const actionmenuSlice = createSlice({
           ...initialModalList,
           form: {
             ...initialFormState,
-            [action.payload.key]: action.payload.value
-          }
-        }
+            [action.payload.key]: action.payload.value,
+          },
+        },
       };
     },
     setConfirmState(state, action) {
@@ -130,31 +118,13 @@ export const actionmenuSlice = createSlice({
           ...initialModalList,
           confirm: {
             ...initialConfirmState,
-            [action.payload.key]: action.payload.value
-          }
-        }
+            [action.payload.key]: action.payload.value,
+          },
+        },
       };
     },
   },
 });
-
-export function selectIsLatest() {
-  return (state: AppState) => state.actionmenu.isLatest;
-}
-
-export function setIsLatest(isLatest?: boolean): AppThunk {
-  return (dispatch) =>
-    dispatch(actionmenuSlice.actions.setIsLatest(isLatest ?? false));
-}
-
-export function selectIsPublished() {
-  return (state: AppState) => state.actionmenu.isPublished;
-}
-
-export function setIsPublished(isPublished?: boolean): AppThunk {
-  return (dispatch) =>
-    dispatch(actionmenuSlice.actions.setIsPublished(isPublished ?? false));
-}
 
 export function selectIsCrosswalk() {
   return (state: AppState) => state.actionmenu.isCrosswalk;
@@ -174,7 +144,8 @@ export function setMenuList(menuList: Array<keyof MenuList>): AppThunk {
 }
 
 export function resetMenuList(): AppThunk {
-  return (dispatch) => dispatch(actionmenuSlice.actions.setMenuListFull(initialMenuList));
+  return (dispatch) =>
+    dispatch(actionmenuSlice.actions.setMenuListFull(initialMenuList));
 }
 
 export function selectModal() {
@@ -185,7 +156,10 @@ export function selectFormModalState() {
   return (state: AppState) => state.actionmenu.modal.form;
 }
 
-export function setFormModalState(formType: {key: keyof FormState; value: boolean}): AppThunk {
+export function setFormModalState(formType: {
+  key: keyof FormState;
+  value: boolean;
+}): AppThunk {
   return (dispatch) => dispatch(actionmenuSlice.actions.setFormState(formType));
 }
 
@@ -193,6 +167,10 @@ export function selectConfirmModalState() {
   return (state: AppState) => state.actionmenu.modal.confirm;
 }
 
-export function setConfirmModalState(confirmType: {key: keyof ConfirmState; value: boolean}): AppThunk {
-  return (dispatch) => dispatch(actionmenuSlice.actions.setConfirmState(confirmType));
+export function setConfirmModalState(confirmType: {
+  key: keyof ConfirmState;
+  value: boolean;
+}): AppThunk {
+  return (dispatch) =>
+    dispatch(actionmenuSlice.actions.setConfirmState(confirmType));
 }

--- a/mscr-ui/src/common/components/generic-table/generic-table.styles.tsx
+++ b/mscr-ui/src/common/components/generic-table/generic-table.styles.tsx
@@ -1,5 +1,10 @@
 import styled from 'styled-components';
-import { TableCell, TableHead, TableRow } from '@mui/material';
+import { TableCell, TableContainer, TableHead, TableRow } from '@mui/material';
+
+export const StyledTableContainer = styled(TableContainer)`
+  border: 1px solid ${(props) => props.theme.suomifi.colors.depthLight1};
+  border-radius: 3px;
+`;
 
 export const StyledTableCell = styled(TableCell)(({ theme }) => ({}));
 

--- a/mscr-ui/src/common/components/generic-table/index.tsx
+++ b/mscr-ui/src/common/components/generic-table/index.tsx
@@ -1,9 +1,10 @@
-import { Grid, Table, TableBody, TableContainer } from '@mui/material';
+import { Grid, Table, TableBody } from '@mui/material';
 import * as React from 'react';
 import {
   StyledTableCell,
   StyledTableRow,
   StyledTableHead,
+  StyledTableContainer
 } from '@app/common/components/generic-table/generic-table.styles';
 
 // Usage: items can be an array of typed items e.g. FilesRow[]. Heading names are taken from the interface property names. Headings can be over-ridden with using headings array.
@@ -80,12 +81,12 @@ export default function GenericTable(props: {
           <h2>{props.caption}</h2>
         </Grid>
         )}
-        <TableContainer>
+        <StyledTableContainer>
           <Table aria-label={props.caption}>
             {createColumnHeadings(props.items as { [s: string]: unknown }[])}
             {createColumns(props.items as { [s: string]: unknown }[])}
           </Table>
-        </TableContainer>
+        </StyledTableContainer>
       </Grid>
     </>
   );

--- a/mscr-ui/src/common/components/layout/index.tsx
+++ b/mscr-ui/src/common/components/layout/index.tsx
@@ -5,7 +5,6 @@ import Notification from '@app/common/components/notifications';
 
 interface LayoutProps {
   user?: MscrUser | null;
-  sideNavigationHidden?: boolean;
   fakeableUsers?: FakeableUser[] | null;
   isActionMenu?: boolean;
   children: React.ReactNode;
@@ -13,7 +12,6 @@ interface LayoutProps {
 
 export default function Layout({
   user,
-  sideNavigationHidden,
   fakeableUsers,
   isActionMenu,
   children,
@@ -21,7 +19,6 @@ export default function Layout({
   return (
     <CommonLayout
       user={user ?? undefined}
-      sideNavigationHidden={sideNavigationHidden ?? false}
       fakeableUsers={fakeableUsers ?? []}
       isActionMenu={isActionMenu ?? false}
       alerts={<Notification />}

--- a/mscr-ui/src/common/components/layout/layout.styles.tsx
+++ b/mscr-ui/src/common/components/layout/layout.styles.tsx
@@ -7,10 +7,10 @@ import { small } from 'yti-common-ui/media-query/styled-helpers';
 export const MarginContainer = styled.div<{
   $breakpoint: Breakpoint;
 }>`
+  margin: ${(props) => props.theme.suomifi.spacing.s};
   &&.hidden {
     visibility: hidden;
   }
-  margin: auto;
   padding-right: 1rem;
   padding-left: 1rem;
 `;
@@ -18,9 +18,14 @@ export const MarginContainer = styled.div<{
 // main layout
 
 export const SiteContainer = styled.div`
-  width: 100%;
-  margin: auto;
-  height: 100vh;
+  display: flex;
+  flex-direction: column;
+`;
+
+export const FlexContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: start;
 `;
 
 export const NavigationContainer = styled.div<{ $breakpoint: Breakpoint }>`
@@ -32,7 +37,6 @@ export const NavigationContainer = styled.div<{ $breakpoint: Breakpoint }>`
 // content layout
 
 export const ContentContainer = styled.div<{ $fullScreen?: boolean }>`
-  margin-left: 10px;
   background-color: ${(props) =>
     props.$fullScreen
       ? props.theme.suomifi.colors.whiteBase

--- a/mscr-ui/src/common/components/layout/layout.styles.tsx
+++ b/mscr-ui/src/common/components/layout/layout.styles.tsx
@@ -24,7 +24,7 @@ export const SiteContainer = styled.div`
 
 export const FlexContainer = styled.div`
   display: flex;
-  flex-direction: row;
+  flex-direction: row-reverse;
   align-items: start;
 `;
 

--- a/mscr-ui/src/common/components/layout/layout.tsx
+++ b/mscr-ui/src/common/components/layout/layout.tsx
@@ -21,14 +21,12 @@ import ActionPanel from '@app/common/components/action-panel';
 
 export default function Layout({
   children,
-  sideNavigationHidden,
   user,
   fakeableUsers,
   isActionMenu,
   alerts,
 }: {
   children: React.ReactNode;
-  sideNavigationHidden: boolean;
   user?: MscrUser;
   fakeableUsers?: FakeableUser[] | null;
   isActionMenu?: boolean;
@@ -56,9 +54,8 @@ export default function Layout({
               fakeableUsers
             )}
           />
-          {!sideNavigationHidden && user && !user.anonymous ? (
+          {user && !user.anonymous ? (
             <FlexContainer>
-              <SideNavigationPanel user={user}/>
               <ContentContainer>
                 {alerts && alerts}
                 <MarginContainer
@@ -70,6 +67,7 @@ export default function Layout({
                   {children}
                 </MarginContainer>
               </ContentContainer>
+              <SideNavigationPanel user={user}/>
             </FlexContainer>
           ) : (
             <ContentContainer className={'w-100'}>

--- a/mscr-ui/src/common/components/layout/layout.tsx
+++ b/mscr-ui/src/common/components/layout/layout.tsx
@@ -5,6 +5,7 @@ import {
   ContentContainer,
   SiteContainer,
   MarginContainer,
+  FlexContainer
 } from './layout.styles';
 import { useTranslation } from 'next-i18next';
 import SmartHeader from '../smart-header';
@@ -56,9 +57,9 @@ export default function Layout({
             )}
           />
           {!sideNavigationHidden && user && !user.anonymous ? (
-            <div className={'d-flex w-100'}>
+            <FlexContainer>
               <SideNavigationPanel user={user}/>
-              <ContentContainer className={'w-100'}>
+              <ContentContainer>
                 {alerts && alerts}
                 <MarginContainer
                   $breakpoint={breakpoint}
@@ -69,7 +70,7 @@ export default function Layout({
                   {children}
                 </MarginContainer>
               </ContentContainer>
-            </div>
+            </FlexContainer>
           ) : (
             <ContentContainer className={'w-100'}>
               {alerts && alerts}

--- a/mscr-ui/src/common/components/navigation/navigation.slice.tsx
+++ b/mscr-ui/src/common/components/navigation/navigation.slice.tsx
@@ -1,0 +1,42 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { AppState, AppThunk } from '@app/store';
+
+const initialState = {
+  isSideNavigationMinimized: false,
+  showFadeInAnimation: false,
+};
+
+export const navigationSlice = createSlice({
+  name: 'navigation',
+  initialState: initialState,
+  reducers: {
+    setIsSideNavigationMinimized(state, action) {
+      return {
+        ...state,
+        isSideNavigationMinimized: action.payload
+      };
+    },
+    setShowFadeInAnimation(state, action) {
+      return {
+        ...state,
+        showFadeInAnimation: action.payload
+      };
+    },
+  },
+});
+
+export function selectIsSideNavigationMinimized() {
+  return (state: AppState) => state.navigation.isSideNavigationMinimized;
+}
+
+export function setIsSideNavigationMinimized(isMinimized?: boolean): AppThunk {
+  return (dispatch) => dispatch(navigationSlice.actions.setIsSideNavigationMinimized(isMinimized ?? false));
+}
+
+export function selectShowFadeInAnimation() {
+  return (state: AppState) => state.navigation.showFadeInAnimation;
+}
+
+export function setShowFadeInAnimation(showAnimation?: boolean): AppThunk {
+  return (dispatch) => dispatch(navigationSlice.actions.setShowFadeInAnimation(showAnimation ?? false));
+}

--- a/mscr-ui/src/common/components/pagination/index.tsx
+++ b/mscr-ui/src/common/components/pagination/index.tsx
@@ -1,6 +1,6 @@
-import { Pagination as SFPagination } from 'suomifi-ui-components';
 import { useTranslation } from 'next-i18next';
 import useUrlState from '@app/common/utils/hooks/use-url-state';
+import { StyledPagination } from '@app/common/components/pagination/pagination.styles';
 
 interface PaginationProps {
   lastPage: number;
@@ -12,7 +12,7 @@ export default function Pagination({
   const { t } = useTranslation('common');
   const { urlState, patchUrlState } = useUrlState();
   return (
-    <SFPagination
+    <StyledPagination
       aria-label={t('pagination.aria.label')}
       pageIndicatorText={(currentPage, lastPage) =>
         t('pagination.page') + ' ' + currentPage + ' / ' + lastPage

--- a/mscr-ui/src/common/components/pagination/pagination.styles.tsx
+++ b/mscr-ui/src/common/components/pagination/pagination.styles.tsx
@@ -1,0 +1,6 @@
+import styled from 'styled-components';
+import { Pagination } from 'suomifi-ui-components';
+
+export const StyledPagination = styled(Pagination)`
+  margin-top: ${(props) => props.theme.suomifi.spacing.xs};
+`;

--- a/mscr-ui/src/common/components/side-navigation/index.tsx
+++ b/mscr-ui/src/common/components/side-navigation/index.tsx
@@ -13,7 +13,10 @@ import {
   FoldButton,
   FoldButtonWrapper,
   MscrSideNavigationLevel1,
-  GroupButton
+  GroupButton,
+  ExpanderButton,
+  CollapsedNavigationWrapper,
+  PersonalNavButton
 } from './side-navigation.styles';
 import { useTranslation } from 'next-i18next';
 import { useContext, useState } from 'react';
@@ -62,172 +65,184 @@ export default function SideNavigationPanel({ user }: { user?: MscrUser }) {
     }
   };
 
+  const collapsedMenu = () => {
+    return (
+      <CollapsedNavigationWrapper>
+        <PersonalNavButton>P</PersonalNavButton>
+      </CollapsedNavigationWrapper>
+    );
+  };
+
+  // return collapsedMenu();
+
   return (
     <SideNavigationWrapper
       $breakpoint={breakpoint}
       $isSidebarFolded={isSidebarMinimized}
       id="sidebar"
     >
-      <div className={'d-flex justify-content-between'}>
-        <div className={''}>
-          <div
-            className={
-              !isSidebarMinimized && !isFirstPageLoad
-                ? 'sidebar-animate-fadein'
-                : undefined
-            }
-          >
-            <MscrSideNavigation
-              heading=""
-              aria-label={t('workspace.navigation')}
-              className={
-                isSidebarMinimized ? 'sidebar-animate-fadeout' : undefined
+      <MscrSideNavigation
+        heading=""
+        aria-label={t('workspace.navigation')}
+        className={
+          isSidebarMinimized ? 'sidebar-animate-fadeout' : undefined
+        }
+      >
+        <MscrSideNavigationLevel1
+          subLevel={1}
+          expanded
+          content={
+            <NavigationHeading variant="h2">
+              {t('workspace.personal')}
+            </NavigationHeading>
+          }
+        >
+          <PersonalNavigationWrapper>
+            <MscrSideNavigationLevel3
+              className="personal"
+              subLevel={3}
+              selected={router.asPath.startsWith(personalCrosswalksPath)}
+              content={
+                <Link href={personalCrosswalksPath} passHref>
+                  <RouterLink
+                    onClick={() => {
+                      setOpenGroup([]);
+                      setIsSearchActive(false);
+                    }}
+                  >
+                    {t('workspace.crosswalks')}
+                  </RouterLink>
+                </Link>
+              }
+            />
+            <MscrSideNavigationLevel3
+              className="personal"
+              subLevel={3}
+              selected={router.asPath.startsWith(personalSchemasPath)}
+              content={
+                <Link href={personalSchemasPath} passHref>
+                  <RouterLink
+                    onClick={() => {
+                      setOpenGroup([]);
+                      setIsSearchActive(false);
+                    }}
+                  >
+                    {t('workspace.schemas')}
+                  </RouterLink>
+                </Link>
+              }
+            />
+            <MscrSideNavigationLevel3
+              className="personal"
+              subLevel={3}
+              selected={router.asPath.startsWith(personalSettingsPath)}
+              content={''}
+            />
+          </PersonalNavigationWrapper>
+        </MscrSideNavigationLevel1>
+        <MscrSideNavigationLevel1
+          subLevel={1}
+          expanded
+          content={
+            <NavigationHeading variant="h2">
+              {t('workspace.group')}
+            </NavigationHeading>
+          }
+        >
+          {organizations?.map((group) => (
+            <MscrSideNavigationLevel2
+              key={group.id}
+              subLevel={2}
+              selected={openGroup.includes(group.id)}
+              className={openGroup.includes(group.id) ? 'group-selected' : ''}
+              content={
+                <GroupButton
+                  onClick={() => handleClickGroup(group.id)}
+                >
+                  <Heading variant="h3">{group.label}</Heading>
+                  {openGroup.includes(group.id) && <IconChevronUp />}
+                  {!openGroup.includes(group.id) && <IconChevronDown />}
+                </GroupButton>
               }
             >
-              <MscrSideNavigationLevel1
-                subLevel={1}
-                expanded
+              <MscrSideNavigationLevel3
+                className="group"
+                subLevel={3}
+                selected={router.asPath.startsWith(
+                  '/' + group.id + '/crosswalks'
+                )}
                 content={
-                  <NavigationHeading variant="h2">
-                    {t('workspace.personal')}
-                  </NavigationHeading>
+                  <Link href={'/' + group.id + '/crosswalks'} passHref>
+                    <RouterLink onClick={() => setIsSearchActive(false)}>
+                      {t('workspace.crosswalks')}
+                    </RouterLink>
+                  </Link>
                 }
-              >
-                <PersonalNavigationWrapper>
-                  <MscrSideNavigationLevel3
-                    className="personal"
-                    subLevel={3}
-                    selected={router.asPath.startsWith(personalCrosswalksPath)}
-                    content={
-                      <Link href={personalCrosswalksPath} passHref>
-                        <RouterLink
-                          onClick={() => {
-                            setOpenGroup([]);
-                            setIsSearchActive(false);
-                          }}
-                        >
-                          {t('workspace.crosswalks')}
-                        </RouterLink>
-                      </Link>
-                    }
-                  />
-                  <MscrSideNavigationLevel3
-                    className="personal"
-                    subLevel={3}
-                    selected={router.asPath.startsWith(personalSchemasPath)}
-                    content={
-                      <Link href={personalSchemasPath} passHref>
-                        <RouterLink
-                          onClick={() => {
-                            setOpenGroup([]);
-                            setIsSearchActive(false);
-                          }}
-                        >
-                          {t('workspace.schemas')}
-                        </RouterLink>
-                      </Link>
-                    }
-                  />
-                  <MscrSideNavigationLevel3
-                    className="personal"
-                    subLevel={3}
-                    selected={router.asPath.startsWith(personalSettingsPath)}
-                    content={''}
-                  />
-                </PersonalNavigationWrapper>
-              </MscrSideNavigationLevel1>
-              <MscrSideNavigationLevel1
-                subLevel={1}
-                expanded
+              />
+              <MscrSideNavigationLevel3
+                className="group"
+                subLevel={3}
+                selected={router.asPath.startsWith(
+                  '/' + group.id + '/schemas'
+                )}
                 content={
-                  <NavigationHeading variant="h2">
-                    {t('workspace.group')}
-                  </NavigationHeading>
+                  <Link href={'/' + group.id + '/schemas'} passHref>
+                    <RouterLink onClick={() => setIsSearchActive(false)}>
+                      {t('workspace.schemas')}
+                    </RouterLink>
+                  </Link>
                 }
-              >
-                {organizations?.map((group) => (
-                  <MscrSideNavigationLevel2
-                    key={group.id}
-                    subLevel={2}
-                    selected={openGroup.includes(group.id)}
-                    className={openGroup.includes(group.id) ? 'group-selected' : ''}
-                    content={
-                      <GroupButton
-                        onClick={() => handleClickGroup(group.id)}
-                      >
-                        <Heading variant="h3">{group.label}</Heading>
-                        {openGroup.includes(group.id) && <IconChevronUp />}
-                        {!openGroup.includes(group.id) && <IconChevronDown />}
-                      </GroupButton>
-                    }
-                  >
-                    <MscrSideNavigationLevel3
-                      className="group"
-                      subLevel={3}
-                      selected={router.asPath.startsWith(
-                        '/' + group.id + '/crosswalks'
-                      )}
-                      content={
-                        <Link href={'/' + group.id + '/crosswalks'} passHref>
-                          <RouterLink onClick={() => setIsSearchActive(false)}>
-                            {t('workspace.crosswalks')}
-                          </RouterLink>
-                        </Link>
-                      }
-                    />
-                    <MscrSideNavigationLevel3
-                      className="group"
-                      subLevel={3}
-                      selected={router.asPath.startsWith(
-                        '/' + group.id + '/schemas'
-                      )}
-                      content={
-                        <Link href={'/' + group.id + '/schemas'} passHref>
-                          <RouterLink onClick={() => setIsSearchActive(false)}>
-                            {t('workspace.schemas')}
-                          </RouterLink>
-                        </Link>
-                      }
-                    />
-                    <MscrSideNavigationLevel3
-                      className="group"
-                      subLevel={3}
-                      selected={router.asPath.startsWith(
-                        '/' + group.id + '/settings'
-                      )}
-                      content={''}
-                    />
-                  </MscrSideNavigationLevel2>
-                ))}
-              </MscrSideNavigationLevel1>
-            </MscrSideNavigation>
-          </div>
-        </div>
-        <FoldButtonWrapper
-          className={'col-1 d-flex justify-content-center flex-column'}
-        >
-          <Tooltip
-            title={
-              isSidebarMinimized
-                ? t('click-to-expand-sidebar')
-                : t('click-to-minimize-sidebar')
-            }
-            placement="top-end"
-            className={undefined}
-          >
-            <FoldButton
-              aria-label="fold"
-              onClick={(e) => {
-                sidebarFoldButtonClick();
-                e.stopPropagation();
-              }}
-            >
-              <div></div>
-              <div></div>
-            </FoldButton>
-          </Tooltip>
-        </FoldButtonWrapper>
-      </div>
+              />
+              <MscrSideNavigationLevel3
+                className="group"
+                subLevel={3}
+                selected={router.asPath.startsWith(
+                  '/' + group.id + '/settings'
+                )}
+                content={''}
+              />
+            </MscrSideNavigationLevel2>
+          ))}
+        </MscrSideNavigationLevel1>
+      </MscrSideNavigation>
+      {/*<div className={'d-flex justify-content-between'}>*/}
+
+        {/*<div className={''}>*/}
+        {/*  <div*/}
+        {/*    className={*/}
+        {/*      !isSidebarMinimized && !isFirstPageLoad*/}
+        {/*        ? 'sidebar-animate-fadein'*/}
+        {/*        : undefined*/}
+        {/*    }*/}
+        {/*  >*/}
+        {/*    */}
+        {/*  </div>*/}
+        {/*</div>*/}
+        {/*<FoldButtonWrapper*/}
+        {/*  className={'col-1 d-flex justify-content-center flex-column'}*/}
+        {/*>*/}
+        {/*  <Tooltip*/}
+        {/*    title={*/}
+        {/*      isSidebarMinimized*/}
+        {/*        ? t('click-to-expand-sidebar')*/}
+        {/*        : t('click-to-minimize-sidebar')*/}
+        {/*    }*/}
+        {/*    placement="top-end"*/}
+        {/*    className={undefined}*/}
+        {/*  >*/}
+        {/*    <FoldButton*/}
+        {/*      aria-label="fold"*/}
+        {/*      onClick={(e) => {*/}
+        {/*        sidebarFoldButtonClick();*/}
+        {/*        e.stopPropagation();*/}
+        {/*      }}*/}
+        {/*    >*/}
+        {/*      <div></div>*/}
+        {/*      <div></div>*/}
+        {/*    </FoldButton>*/}
+        {/*  </Tooltip>*/}
+        {/*</FoldButtonWrapper>*/}
+      {/*</div>*/}
     </SideNavigationWrapper>
   );
 }

--- a/mscr-ui/src/common/components/side-navigation/index.tsx
+++ b/mscr-ui/src/common/components/side-navigation/index.tsx
@@ -13,12 +13,12 @@ import {
   MscrSideNavigationLevel1,
   GroupButton,
   ExpanderButton,
-  CollapsedNavigationWrapper,
+  MinimizedNavigationWrapper,
   ExpanderIcon,
   GroupNavIcon,
-  CollapsedGroupItem,
-  CollapsedGroupList,
-  PopoverNavigationMenu
+  MinimizedGroupItem,
+  MinimizedGroupList,
+  PopoverNavigationMenu,
 } from './side-navigation.styles';
 import { useTranslation } from 'next-i18next';
 import { useContext, useState } from 'react';
@@ -30,7 +30,7 @@ import { useStoreDispatch } from '@app/store';
 import { useSelector } from 'react-redux';
 import {
   selectIsSideNavigationMinimized,
-  setIsSideNavigationMinimized
+  setIsSideNavigationMinimized,
 } from '@app/common/components/navigation/navigation.slice';
 
 export default function SideNavigationPanel({ user }: { user?: MscrUser }) {
@@ -48,22 +48,13 @@ export default function SideNavigationPanel({ user }: { user?: MscrUser }) {
   // Paths for now
   const personalSchemasPath = '/personal/schemas';
   const personalCrosswalksPath = '/personal/crosswalks';
-  const personalSettingsPath = '/personal/settings';
-  // Group settings path is form '/' + group.id + '/settings'
+  // group urls have the group id instead of 'personal'
   const organizations = getOrganizations(user?.organizations, lang);
-  const [isSidebarMinimized, setSidebarMinimized] = useState(false);
-  const [isFirstPageLoad, setFirstPageLoad] = useState(true);
 
-  function sidebarFoldButtonClick() {
-    //console.log('is folded', isSidebarFolded);
-    setSidebarMinimized(!isSidebarMinimized);
+  const handleClickMinimizeButton = () => {
+    dispatch(setIsSideNavigationMinimized(!isSidebarMinimized));
     setFirstPageLoad(false);
-  }
-  // ToDo: Remove
-  organizations.push({
-    id: 'whateverererereer',
-    label: 'Diligent professionals',
-  });
+  };
 
   const handleClickGroup = (groupId: string) => {
     if (router.asPath.startsWith('/' + groupId)) {
@@ -135,12 +126,6 @@ export default function SideNavigationPanel({ user }: { user?: MscrUser }) {
                 </Link>
               }
             />
-            <MscrSideNavigationLevel3
-              className="personal"
-              subLevel={3}
-              selected={router.asPath.startsWith(personalSettingsPath)}
-              content={''}
-            />
           </PersonalNavigationWrapper>
         </MscrSideNavigationLevel1>
         <MscrSideNavigationLevel1
@@ -192,14 +177,6 @@ export default function SideNavigationPanel({ user }: { user?: MscrUser }) {
                   </Link>
                 }
               />
-              <MscrSideNavigationLevel3
-                className="group"
-                subLevel={3}
-                selected={router.asPath.startsWith(
-                  '/' + group.id + '/settings'
-                )}
-                content={''}
-              />
             </MscrSideNavigationLevel2>
           ))}
         </MscrSideNavigationLevel1>
@@ -207,10 +184,10 @@ export default function SideNavigationPanel({ user }: { user?: MscrUser }) {
     );
   };
 
-  const collapsedMenu = () => {
+  const minimizedMenu = () => {
     return (
-      <nav>
-        <CollapsedNavigationWrapper
+      <div>
+        <MinimizedNavigationWrapper
           className={
             isSidebarMinimized && !isFirstPageLoad
               ? 'sidebar-animate-fadein'
@@ -250,9 +227,9 @@ export default function SideNavigationPanel({ user }: { user?: MscrUser }) {
           <GroupNavIcon>
             <p>G</p>
           </GroupNavIcon>
-          <CollapsedGroupList>
+          <MinimizedGroupList>
             {organizations.map((group) => (
-              <CollapsedGroupItem key={group.id}>
+              <MinimizedGroupItem key={group.id}>
                 <PopoverNavigationMenu
                   className="group"
                   buttonText={group.label.substring(0, 2).toUpperCase()}
@@ -281,21 +258,20 @@ export default function SideNavigationPanel({ user }: { user?: MscrUser }) {
                     </Link>
                   </ActionMenuItem>
                 </PopoverNavigationMenu>
-              </CollapsedGroupItem>
+              </MinimizedGroupItem>
             ))}
-          </CollapsedGroupList>
-        </CollapsedNavigationWrapper>
-      </nav>
+          </MinimizedGroupList>
+        </MinimizedNavigationWrapper>
+      </div>
     );
   };
 
   return (
     <SideNavigationWrapper
       $breakpoint={breakpoint}
-      $isSidebarFolded={isSidebarMinimized}
-      id="sidebar"
+      $isSidebarMinimized={isSidebarMinimized}
     >
-      {isSidebarMinimized && collapsedMenu()}
+      {isSidebarMinimized && minimizedMenu()}
       {!isSidebarMinimized && expandedMenu()}
       <Tooltip
         title={
@@ -304,9 +280,8 @@ export default function SideNavigationPanel({ user }: { user?: MscrUser }) {
             : t('click-to-minimize-sidebar')
         }
         placement="right"
-        className={undefined}
       >
-        <ExpanderButton onClick={() => sidebarFoldButtonClick()}>
+        <ExpanderButton onClick={() => handleClickMinimizeButton()}>
           <ExpanderIcon />
         </ExpanderButton>
       </Tooltip>

--- a/mscr-ui/src/common/components/side-navigation/index.tsx
+++ b/mscr-ui/src/common/components/side-navigation/index.tsx
@@ -26,6 +26,12 @@ import { useRouter } from 'next/router';
 import { MscrUser } from '@app/common/interfaces/mscr-user.interface';
 import getOrganizations from '@app/common/utils/get-organizations';
 import { SearchContext } from '@app/common/components/search-context-provider';
+import { useStoreDispatch } from '@app/store';
+import { useSelector } from 'react-redux';
+import {
+  selectIsSideNavigationMinimized,
+  setIsSideNavigationMinimized
+} from '@app/common/components/navigation/navigation.slice';
 
 export default function SideNavigationPanel({ user }: { user?: MscrUser }) {
   const { breakpoint } = useBreakpoints();
@@ -33,6 +39,9 @@ export default function SideNavigationPanel({ user }: { user?: MscrUser }) {
   const { setIsSearchActive } = useContext(SearchContext);
   const router = useRouter();
   const lang = router.locale ?? '';
+  const dispatch = useStoreDispatch();
+  const isSidebarMinimized = useSelector(selectIsSideNavigationMinimized());
+  const [isFirstPageLoad, setFirstPageLoad] = useState(true);
   const [openGroup, setOpenGroup] = useState([
     router.query['homepage']?.toString() ?? '',
   ]);
@@ -203,9 +212,11 @@ export default function SideNavigationPanel({ user }: { user?: MscrUser }) {
       <nav>
         <CollapsedNavigationWrapper
           className={
-            isSidebarMinimized
+            isSidebarMinimized && !isFirstPageLoad
               ? 'sidebar-animate-fadein'
-              : 'sidebar-animate-fadeout'
+              : !isSidebarMinimized
+                ? 'sidebar-animate-fadeout'
+                : undefined
           }
         >
           <PopoverNavigationMenu
@@ -286,45 +297,6 @@ export default function SideNavigationPanel({ user }: { user?: MscrUser }) {
     >
       {isSidebarMinimized && collapsedMenu()}
       {!isSidebarMinimized && expandedMenu()}
-
-      {/*<div className={'d-flex justify-content-between'}>*/}
-
-      {/*<div className={''}>*/}
-      {/*  <div*/}
-      {/*    className={*/}
-      {/*      !isSidebarMinimized && !isFirstPageLoad*/}
-      {/*        ? 'sidebar-animate-fadein'*/}
-      {/*        : undefined*/}
-      {/*    }*/}
-      {/*  >*/}
-      {/*    */}
-      {/*  </div>*/}
-      {/*</div>*/}
-      {/*<FoldButtonWrapper*/}
-      {/*  className={'col-1 d-flex justify-content-center flex-column'}*/}
-      {/*>*/}
-      {/*  <Tooltip*/}
-      {/*    title={*/}
-      {/*      isSidebarMinimized*/}
-      {/*        ? t('click-to-expand-sidebar')*/}
-      {/*        : t('click-to-minimize-sidebar')*/}
-      {/*    }*/}
-      {/*    placement="top-end"*/}
-      {/*    className={undefined}*/}
-      {/*  >*/}
-      {/*    <FoldButton*/}
-      {/*      aria-label="fold"*/}
-      {/*      onClick={(e) => {*/}
-      {/*        sidebarFoldButtonClick();*/}
-      {/*        e.stopPropagation();*/}
-      {/*      }}*/}
-      {/*    >*/}
-      {/*      <div></div>*/}
-      {/*      <div></div>*/}
-      {/*    </FoldButton>*/}
-      {/*  </Tooltip>*/}
-      {/*</FoldButtonWrapper>*/}
-      {/*</div>*/}
       <Tooltip
         title={
           isSidebarMinimized

--- a/mscr-ui/src/common/components/side-navigation/index.tsx
+++ b/mscr-ui/src/common/components/side-navigation/index.tsx
@@ -10,13 +10,15 @@ import {
   MscrSideNavigationLevel3,
   PersonalNavigationWrapper,
   MscrSideNavigation,
-  FoldButton,
-  FoldButtonWrapper,
   MscrSideNavigationLevel1,
   GroupButton,
   ExpanderButton,
   CollapsedNavigationWrapper,
-  PersonalNavButton
+  PersonalNavButton,
+  ExpanderIcon,
+  GroupNavIcon,
+  CollapsedGroupItem,
+  CollapsedGroupList,
 } from './side-navigation.styles';
 import { useTranslation } from 'next-i18next';
 import { useContext, useState } from 'react';
@@ -31,7 +33,9 @@ export default function SideNavigationPanel({ user }: { user?: MscrUser }) {
   const { setIsSearchActive } = useContext(SearchContext);
   const router = useRouter();
   const lang = router.locale ?? '';
-  const [openGroup, setOpenGroup] = useState([router.query['homepage']?.toString() ?? '']);
+  const [openGroup, setOpenGroup] = useState([
+    router.query['homepage']?.toString() ?? '',
+  ]);
   // Paths for now
   const personalSchemasPath = '/personal/schemas';
   const personalCrosswalksPath = '/personal/crosswalks';
@@ -65,27 +69,18 @@ export default function SideNavigationPanel({ user }: { user?: MscrUser }) {
     }
   };
 
-  const collapsedMenu = () => {
+  const expandedMenu = () => {
     return (
-      <CollapsedNavigationWrapper>
-        <PersonalNavButton>P</PersonalNavButton>
-      </CollapsedNavigationWrapper>
-    );
-  };
-
-  // return collapsedMenu();
-
-  return (
-    <SideNavigationWrapper
-      $breakpoint={breakpoint}
-      $isSidebarFolded={isSidebarMinimized}
-      id="sidebar"
-    >
       <MscrSideNavigation
+        $isSidebarFolded={isSidebarMinimized}
         heading=""
         aria-label={t('workspace.navigation')}
         className={
-          isSidebarMinimized ? 'sidebar-animate-fadeout' : undefined
+          !isSidebarMinimized && !isFirstPageLoad
+            ? 'sidebar-animate-fadein'
+            : isSidebarMinimized
+              ? 'sidebar-animate-fadeout'
+              : undefined
         }
       >
         <MscrSideNavigationLevel1
@@ -156,9 +151,7 @@ export default function SideNavigationPanel({ user }: { user?: MscrUser }) {
               selected={openGroup.includes(group.id)}
               className={openGroup.includes(group.id) ? 'group-selected' : ''}
               content={
-                <GroupButton
-                  onClick={() => handleClickGroup(group.id)}
-                >
+                <GroupButton onClick={() => handleClickGroup(group.id)}>
                   <Heading variant="h3">{group.label}</Heading>
                   {openGroup.includes(group.id) && <IconChevronUp />}
                   {!openGroup.includes(group.id) && <IconChevronDown />}
@@ -182,9 +175,7 @@ export default function SideNavigationPanel({ user }: { user?: MscrUser }) {
               <MscrSideNavigationLevel3
                 className="group"
                 subLevel={3}
-                selected={router.asPath.startsWith(
-                  '/' + group.id + '/schemas'
-                )}
+                selected={router.asPath.startsWith('/' + group.id + '/schemas')}
                 content={
                   <Link href={'/' + group.id + '/schemas'} passHref>
                     <RouterLink onClick={() => setIsSearchActive(false)}>
@@ -205,44 +196,108 @@ export default function SideNavigationPanel({ user }: { user?: MscrUser }) {
           ))}
         </MscrSideNavigationLevel1>
       </MscrSideNavigation>
+    );
+  };
+
+  const collapsedMenu = () => {
+    return (
+      <CollapsedNavigationWrapper
+        className={
+          isSidebarMinimized
+            ? 'sidebar-animate-fadein'
+            : 'sidebar-animate-fadeout'
+        }
+      >
+        <PersonalNavButton>
+          <p>
+            P<IconChevronDown />
+          </p>
+        </PersonalNavButton>
+        <GroupNavIcon>
+          <p>G</p>
+        </GroupNavIcon>
+        <CollapsedGroupList>
+          {organizations.map((group) => (
+            <CollapsedGroupItem key={group.id}>
+              <GroupButton
+                className={'collapsed'}
+                onClick={() => {
+                  return; // Avaa popup-menu
+                }}
+              >
+                <Heading variant="h3">
+                  {group.label.substring(0, 2).toUpperCase()}
+                </Heading>
+                {openGroup.includes(group.id) && <IconChevronUp />}
+                {!openGroup.includes(group.id) && <IconChevronDown />}
+              </GroupButton>
+            </CollapsedGroupItem>
+          ))}
+        </CollapsedGroupList>
+      </CollapsedNavigationWrapper>
+    );
+  };
+
+  return (
+    <SideNavigationWrapper
+      $breakpoint={breakpoint}
+      $isSidebarFolded={isSidebarMinimized}
+      id="sidebar"
+    >
+      {isSidebarMinimized && collapsedMenu()}
+      {!isSidebarMinimized && expandedMenu()}
+
       {/*<div className={'d-flex justify-content-between'}>*/}
 
-        {/*<div className={''}>*/}
-        {/*  <div*/}
-        {/*    className={*/}
-        {/*      !isSidebarMinimized && !isFirstPageLoad*/}
-        {/*        ? 'sidebar-animate-fadein'*/}
-        {/*        : undefined*/}
-        {/*    }*/}
-        {/*  >*/}
-        {/*    */}
-        {/*  </div>*/}
-        {/*</div>*/}
-        {/*<FoldButtonWrapper*/}
-        {/*  className={'col-1 d-flex justify-content-center flex-column'}*/}
-        {/*>*/}
-        {/*  <Tooltip*/}
-        {/*    title={*/}
-        {/*      isSidebarMinimized*/}
-        {/*        ? t('click-to-expand-sidebar')*/}
-        {/*        : t('click-to-minimize-sidebar')*/}
-        {/*    }*/}
-        {/*    placement="top-end"*/}
-        {/*    className={undefined}*/}
-        {/*  >*/}
-        {/*    <FoldButton*/}
-        {/*      aria-label="fold"*/}
-        {/*      onClick={(e) => {*/}
-        {/*        sidebarFoldButtonClick();*/}
-        {/*        e.stopPropagation();*/}
-        {/*      }}*/}
-        {/*    >*/}
-        {/*      <div></div>*/}
-        {/*      <div></div>*/}
-        {/*    </FoldButton>*/}
-        {/*  </Tooltip>*/}
-        {/*</FoldButtonWrapper>*/}
+      {/*<div className={''}>*/}
+      {/*  <div*/}
+      {/*    className={*/}
+      {/*      !isSidebarMinimized && !isFirstPageLoad*/}
+      {/*        ? 'sidebar-animate-fadein'*/}
+      {/*        : undefined*/}
+      {/*    }*/}
+      {/*  >*/}
+      {/*    */}
+      {/*  </div>*/}
       {/*</div>*/}
+      {/*<FoldButtonWrapper*/}
+      {/*  className={'col-1 d-flex justify-content-center flex-column'}*/}
+      {/*>*/}
+      {/*  <Tooltip*/}
+      {/*    title={*/}
+      {/*      isSidebarMinimized*/}
+      {/*        ? t('click-to-expand-sidebar')*/}
+      {/*        : t('click-to-minimize-sidebar')*/}
+      {/*    }*/}
+      {/*    placement="top-end"*/}
+      {/*    className={undefined}*/}
+      {/*  >*/}
+      {/*    <FoldButton*/}
+      {/*      aria-label="fold"*/}
+      {/*      onClick={(e) => {*/}
+      {/*        sidebarFoldButtonClick();*/}
+      {/*        e.stopPropagation();*/}
+      {/*      }}*/}
+      {/*    >*/}
+      {/*      <div></div>*/}
+      {/*      <div></div>*/}
+      {/*    </FoldButton>*/}
+      {/*  </Tooltip>*/}
+      {/*</FoldButtonWrapper>*/}
+      {/*</div>*/}
+      <Tooltip
+        title={
+          isSidebarMinimized
+            ? t('click-to-expand-sidebar')
+            : t('click-to-minimize-sidebar')
+        }
+        placement="right"
+        className={undefined}
+      >
+        <ExpanderButton onClick={() => sidebarFoldButtonClick()}>
+          <ExpanderIcon />
+        </ExpanderButton>
+      </Tooltip>
     </SideNavigationWrapper>
   );
 }

--- a/mscr-ui/src/common/components/side-navigation/index.tsx
+++ b/mscr-ui/src/common/components/side-navigation/index.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
-import { Heading, RouterLink, SideNavigationItem } from 'suomifi-ui-components';
+import { Heading, RouterLink } from 'suomifi-ui-components';
+import { IconChevronDown } from 'suomifi-icons';
 import { useBreakpoints } from 'yti-common-ui/media-query';
 import Tooltip from '@mui/material/Tooltip';
 import {
@@ -11,7 +12,8 @@ import {
   MscrSideNavigation,
   GroupOpenButton,
   FoldButton,
-  FoldButtonWrapper, MscrSideNavigationLevel1
+  FoldButtonWrapper,
+  MscrSideNavigationLevel1,
 } from './side-navigation.styles';
 import { useTranslation } from 'next-i18next';
 import { useContext, useState } from 'react';
@@ -41,7 +43,11 @@ export default function SideNavigationPanel({ user }: { user?: MscrUser }) {
     setSidebarMinimized(!isSidebarMinimized);
     setFirstPageLoad(false);
   }
-  organizations.push({id: 'whateverererereer', label: 'Diligent professionals'});
+  // ToDo: Remove
+  organizations.push({
+    id: 'whateverererereer',
+    label: 'Diligent professionals',
+  });
 
   return (
     <SideNavigationWrapper
@@ -133,9 +139,8 @@ export default function SideNavigationPanel({ user }: { user?: MscrUser }) {
                     selected={openGroup == group.id}
                     className={openGroup == group.id ? 'group-selected' : ''}
                     content={
-                      <RouterLink
-                        // Button opens the children that are links to content
-                        asComponent={GroupOpenButton}
+                      <GroupOpenButton
+                        // iconRight={<IconChevronDown />} ToDo: Make work
                         onClick={() => {
                           if (openGroup == group.id) {
                             setOpenGroup('');
@@ -145,7 +150,7 @@ export default function SideNavigationPanel({ user }: { user?: MscrUser }) {
                         }}
                       >
                         <Heading variant="h3">{group.label}</Heading>
-                      </RouterLink>
+                      </GroupOpenButton>
                     }
                   >
                     <MscrSideNavigationLevel3

--- a/mscr-ui/src/common/components/side-navigation/index.tsx
+++ b/mscr-ui/src/common/components/side-navigation/index.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import { Heading, RouterLink } from 'suomifi-ui-components';
-import { IconChevronDown } from 'suomifi-icons';
+import { IconChevronDown, IconChevronUp } from 'suomifi-icons';
 import { useBreakpoints } from 'yti-common-ui/media-query';
 import Tooltip from '@mui/material/Tooltip';
 import {
@@ -10,10 +10,10 @@ import {
   MscrSideNavigationLevel3,
   PersonalNavigationWrapper,
   MscrSideNavigation,
-  GroupOpenButton,
   FoldButton,
   FoldButtonWrapper,
   MscrSideNavigationLevel1,
+  GroupButton
 } from './side-navigation.styles';
 import { useTranslation } from 'next-i18next';
 import { useContext, useState } from 'react';
@@ -26,9 +26,9 @@ export default function SideNavigationPanel({ user }: { user?: MscrUser }) {
   const { breakpoint } = useBreakpoints();
   const { t } = useTranslation('common');
   const { setIsSearchActive } = useContext(SearchContext);
-  const [openGroup, setOpenGroup] = useState('');
   const router = useRouter();
   const lang = router.locale ?? '';
+  const [openGroup, setOpenGroup] = useState([router.query['homepage']?.toString() ?? '']);
   // Paths for now
   const personalSchemasPath = '/personal/schemas';
   const personalCrosswalksPath = '/personal/crosswalks';
@@ -48,6 +48,19 @@ export default function SideNavigationPanel({ user }: { user?: MscrUser }) {
     id: 'whateverererereer',
     label: 'Diligent professionals',
   });
+
+  const handleClickGroup = (groupId: string) => {
+    if (router.asPath.startsWith('/' + groupId)) {
+      return;
+    }
+    if (openGroup.includes(groupId)) {
+      const newOpenGroup = openGroup.filter((id) => id !== groupId);
+      setOpenGroup(newOpenGroup);
+      return;
+    } else {
+      setOpenGroup(openGroup.concat([groupId]));
+    }
+  };
 
   return (
     <SideNavigationWrapper
@@ -89,7 +102,7 @@ export default function SideNavigationPanel({ user }: { user?: MscrUser }) {
                       <Link href={personalCrosswalksPath} passHref>
                         <RouterLink
                           onClick={() => {
-                            setOpenGroup('');
+                            setOpenGroup([]);
                             setIsSearchActive(false);
                           }}
                         >
@@ -106,7 +119,7 @@ export default function SideNavigationPanel({ user }: { user?: MscrUser }) {
                       <Link href={personalSchemasPath} passHref>
                         <RouterLink
                           onClick={() => {
-                            setOpenGroup('');
+                            setOpenGroup([]);
                             setIsSearchActive(false);
                           }}
                         >
@@ -136,21 +149,16 @@ export default function SideNavigationPanel({ user }: { user?: MscrUser }) {
                   <MscrSideNavigationLevel2
                     key={group.id}
                     subLevel={2}
-                    selected={openGroup == group.id}
-                    className={openGroup == group.id ? 'group-selected' : ''}
+                    selected={openGroup.includes(group.id)}
+                    className={openGroup.includes(group.id) ? 'group-selected' : ''}
                     content={
-                      <GroupOpenButton
-                        // iconRight={<IconChevronDown />} ToDo: Make work
-                        onClick={() => {
-                          if (openGroup == group.id) {
-                            setOpenGroup('');
-                            return;
-                          }
-                          setOpenGroup(group.id);
-                        }}
+                      <GroupButton
+                        onClick={() => handleClickGroup(group.id)}
                       >
                         <Heading variant="h3">{group.label}</Heading>
-                      </GroupOpenButton>
+                        {openGroup.includes(group.id) && <IconChevronUp />}
+                        {!openGroup.includes(group.id) && <IconChevronDown />}
+                      </GroupButton>
                     }
                   >
                     <MscrSideNavigationLevel3

--- a/mscr-ui/src/common/components/side-navigation/index.tsx
+++ b/mscr-ui/src/common/components/side-navigation/index.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { Heading, RouterLink } from 'suomifi-ui-components';
+import { ActionMenuItem, Heading, RouterLink } from 'suomifi-ui-components';
 import { IconChevronDown, IconChevronUp } from 'suomifi-icons';
 import { useBreakpoints } from 'yti-common-ui/media-query';
 import Tooltip from '@mui/material/Tooltip';
@@ -14,11 +14,11 @@ import {
   GroupButton,
   ExpanderButton,
   CollapsedNavigationWrapper,
-  PersonalNavButton,
   ExpanderIcon,
   GroupNavIcon,
   CollapsedGroupItem,
   CollapsedGroupList,
+  PopoverNavigationMenu
 } from './side-navigation.styles';
 import { useTranslation } from 'next-i18next';
 import { useContext, useState } from 'react';
@@ -72,7 +72,6 @@ export default function SideNavigationPanel({ user }: { user?: MscrUser }) {
   const expandedMenu = () => {
     return (
       <MscrSideNavigation
-        $isSidebarFolded={isSidebarMinimized}
         heading=""
         aria-label={t('workspace.navigation')}
         className={
@@ -201,40 +200,62 @@ export default function SideNavigationPanel({ user }: { user?: MscrUser }) {
 
   const collapsedMenu = () => {
     return (
-      <CollapsedNavigationWrapper
-        className={
-          isSidebarMinimized
-            ? 'sidebar-animate-fadein'
-            : 'sidebar-animate-fadeout'
-        }
-      >
-        <PersonalNavButton>
-          <p>
-            P<IconChevronDown />
-          </p>
-        </PersonalNavButton>
-        <GroupNavIcon>
-          <p>G</p>
-        </GroupNavIcon>
-        <CollapsedGroupList>
-          {organizations.map((group) => (
-            <CollapsedGroupItem key={group.id}>
-              <GroupButton
-                className={'collapsed'}
-                onClick={() => {
-                  return; // Avaa popup-menu
-                }}
-              >
-                <Heading variant="h3">
-                  {group.label.substring(0, 2).toUpperCase()}
-                </Heading>
-                {openGroup.includes(group.id) && <IconChevronUp />}
-                {!openGroup.includes(group.id) && <IconChevronDown />}
-              </GroupButton>
-            </CollapsedGroupItem>
-          ))}
-        </CollapsedGroupList>
-      </CollapsedNavigationWrapper>
+      <nav>
+        <CollapsedNavigationWrapper
+          className={
+            isSidebarMinimized
+              ? 'sidebar-animate-fadein'
+              : 'sidebar-animate-fadeout'
+          }
+        >
+          <PopoverNavigationMenu className='personal' buttonText='P' iconRight={<IconChevronDown />} >
+            <ActionMenuItem
+              key='crosswalks'
+              onClick={() => {
+                setOpenGroup([]);
+                setIsSearchActive(false);
+              }}
+            >
+              <Link href={personalCrosswalksPath} passHref>
+                {t('workspace.crosswalks')}
+              </Link>
+            </ActionMenuItem>
+            <ActionMenuItem
+              key='schemas'
+              onClick={() => {
+                setOpenGroup([]);
+                setIsSearchActive(false);
+              }}
+            >
+              <Link href={personalSchemasPath} passHref>
+                {t('workspace.schemas')}
+              </Link>
+            </ActionMenuItem>
+          </PopoverNavigationMenu>
+          <GroupNavIcon>
+            <p>G</p>
+          </GroupNavIcon>
+          <CollapsedGroupList>
+            {organizations.map((group) => (
+              <CollapsedGroupItem key={group.id}>
+                <GroupButton
+                  className={'collapsed'}
+                  onClick={() => {
+                    return; // Avaa popup-menu
+                  }}
+                >
+                  <Heading variant="h3">
+                    {group.label.substring(0, 2).toUpperCase()}
+                  </Heading>
+                  {openGroup.includes(group.id) && <IconChevronUp />}
+                  {!openGroup.includes(group.id) && <IconChevronDown />}
+                </GroupButton>
+              </CollapsedGroupItem>
+            ))}
+          </CollapsedGroupList>
+        </CollapsedNavigationWrapper>
+      </nav>
+
     );
   };
 

--- a/mscr-ui/src/common/components/side-navigation/index.tsx
+++ b/mscr-ui/src/common/components/side-navigation/index.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { RouterLink } from 'suomifi-ui-components';
+import { Heading, RouterLink, SideNavigationItem } from 'suomifi-ui-components';
 import { useBreakpoints } from 'yti-common-ui/media-query';
 import Tooltip from '@mui/material/Tooltip';
 import {
@@ -9,12 +9,9 @@ import {
   MscrSideNavigationLevel3,
   PersonalNavigationWrapper,
   MscrSideNavigation,
-  GroupHeading,
   GroupOpenButton,
-  MscrSideNavigationLevel1,
   FoldButton,
-  FoldButtonWrapper,
-  GroupOpenBtn,
+  FoldButtonWrapper, MscrSideNavigationLevel1
 } from './side-navigation.styles';
 import { useTranslation } from 'next-i18next';
 import { useContext, useState } from 'react';
@@ -44,163 +41,174 @@ export default function SideNavigationPanel({ user }: { user?: MscrUser }) {
     setSidebarMinimized(!isSidebarMinimized);
     setFirstPageLoad(false);
   }
+  organizations.push({id: 'whateverererereer', label: 'Diligent professionals'});
 
   return (
-    <SideNavigationWrapper $breakpoint={breakpoint} $isSidebarFolded={isSidebarMinimized} id="sidebar">
+    <SideNavigationWrapper
+      $breakpoint={breakpoint}
+      $isSidebarFolded={isSidebarMinimized}
+      id="sidebar"
+    >
       <div className={'d-flex justify-content-between'}>
         <div className={''}>
-          <div className={!isSidebarMinimized && !isFirstPageLoad ? "sidebar-animate-fadein" :  undefined}>
-            <MscrSideNavigation heading="" aria-label={t('workspace.navigation')}
-                                className={isSidebarMinimized ? "sidebar-animate-fadeout" : undefined}>
-        <MscrSideNavigationLevel1
-          subLevel={1}
-          expanded
-          content={
-            <NavigationHeading variant="h2">
-              {t('workspace.personal')}
-            </NavigationHeading>
-          }
-        >
-          <PersonalNavigationWrapper>
-            <MscrSideNavigationLevel3
-              className="personal"
-              subLevel={3}
-              selected={router.asPath.startsWith(personalSchemasPath)}
-              content={
-                <Link href={personalSchemasPath} passHref>
-                  <RouterLink
-                    onClick={() => {
-                      setOpenGroup('');
-                      setIsSearchActive(false);
-                    }}
-                  >
-                    {t('workspace.schemas')}
-                  </RouterLink>
-                </Link>
-              }
-            />
-            <MscrSideNavigationLevel3
-              className="personal"
-              subLevel={3}
-              selected={router.asPath.startsWith(personalCrosswalksPath)}
-              content={
-                <Link href={personalCrosswalksPath} passHref>
-                  <RouterLink
-                    onClick={() => {
-                      setOpenGroup('');
-                      setIsSearchActive(false);
-                    }}
-                  >
-                    {t('workspace.crosswalks')}
-                  </RouterLink>
-                </Link>
-              }
-            />
-            <MscrSideNavigationLevel3
-              className="personal"
-              subLevel={3}
-              selected={router.asPath.startsWith(personalSettingsPath)}
-              content={''}
-              // content={
-              //   <Link href={personalSettingsPath} passHref>
-              //     <RouterLink onClick={() => setOpenGroup('')}>
-              //       {t('workspace-navigation-settings')}
-              //     </RouterLink>
-              //   </Link>
-              // }
-            />
-          </PersonalNavigationWrapper>
-        </MscrSideNavigationLevel1>
-        <MscrSideNavigationLevel1
-          subLevel={1}
-          expanded
-          content={
-            <NavigationHeading variant="h2">
-              {t('workspace.group')}
-            </NavigationHeading>
-          }
-        >
-          {organizations?.map((group) => (
-            <MscrSideNavigationLevel2
-              key={group.id}
-              subLevel={2}
-              selected={openGroup == group.id}
-              content={
-                <RouterLink
-                  // Button opens the children that are links to content
-                  asComponent={GroupOpenButton}
-                  onClick={() => {
-                    if (openGroup == group.id) {
-                      setOpenGroup('');
-                      return;
-                    }
-                    setOpenGroup(group.id);
-                  }}
-                >
-                  <GroupHeading variant="h3">{group.label}</GroupHeading>
-                </RouterLink>
+          <div
+            className={
+              !isSidebarMinimized && !isFirstPageLoad
+                ? 'sidebar-animate-fadein'
+                : undefined
+            }
+          >
+            <MscrSideNavigation
+              heading=""
+              aria-label={t('workspace.navigation')}
+              className={
+                isSidebarMinimized ? 'sidebar-animate-fadeout' : undefined
               }
             >
-              <MscrSideNavigationLevel3
-                className="group"
-                subLevel={3}
-                selected={router.asPath.startsWith('/' + group.id + '/schemas')}
+              <MscrSideNavigationLevel1
+                subLevel={1}
+                expanded
                 content={
-                  <Link href={'/' + group.id + '/schemas'} passHref>
-                    <RouterLink onClick={() => setIsSearchActive(false)}>
-                      {t('workspace.schemas')}
-                    </RouterLink>
-                  </Link>
+                  <NavigationHeading variant="h2">
+                    {t('workspace.personal')}
+                  </NavigationHeading>
                 }
-              />
-              <MscrSideNavigationLevel3
-                className="group"
-                subLevel={3}
-                selected={router.asPath.startsWith(
-                  '/' + group.id + '/crosswalks'
-                )}
+              >
+                <PersonalNavigationWrapper>
+                  <MscrSideNavigationLevel3
+                    className="personal"
+                    subLevel={3}
+                    selected={router.asPath.startsWith(personalCrosswalksPath)}
+                    content={
+                      <Link href={personalCrosswalksPath} passHref>
+                        <RouterLink
+                          onClick={() => {
+                            setOpenGroup('');
+                            setIsSearchActive(false);
+                          }}
+                        >
+                          {t('workspace.crosswalks')}
+                        </RouterLink>
+                      </Link>
+                    }
+                  />
+                  <MscrSideNavigationLevel3
+                    className="personal"
+                    subLevel={3}
+                    selected={router.asPath.startsWith(personalSchemasPath)}
+                    content={
+                      <Link href={personalSchemasPath} passHref>
+                        <RouterLink
+                          onClick={() => {
+                            setOpenGroup('');
+                            setIsSearchActive(false);
+                          }}
+                        >
+                          {t('workspace.schemas')}
+                        </RouterLink>
+                      </Link>
+                    }
+                  />
+                  <MscrSideNavigationLevel3
+                    className="personal"
+                    subLevel={3}
+                    selected={router.asPath.startsWith(personalSettingsPath)}
+                    content={''}
+                  />
+                </PersonalNavigationWrapper>
+              </MscrSideNavigationLevel1>
+              <MscrSideNavigationLevel1
+                subLevel={1}
+                expanded
                 content={
-                  <Link href={'/' + group.id + '/crosswalks'} passHref>
-                    <RouterLink onClick={() => setIsSearchActive(false)}>
-                      {t('workspace.crosswalks')}
-                    </RouterLink>
-                  </Link>
+                  <NavigationHeading variant="h2">
+                    {t('workspace.group')}
+                  </NavigationHeading>
                 }
-              />
-              <MscrSideNavigationLevel3
-                className="group"
-                subLevel={3}
-                selected={router.asPath.startsWith(
-                  '/' + group.id + '/settings'
-                )}
-
-                content={''}
-                // content={
-                //   <Link href={'/' + group.id + '/settings'} passHref>
-                //     <RouterLink>
-                //       {t('workspace-group-navigation-settings')}
-                //     </RouterLink>
-                //   </Link>
-                // }
-              />
-            </MscrSideNavigationLevel2>
-          ))}
-        </MscrSideNavigationLevel1>
+              >
+                {organizations?.map((group) => (
+                  <MscrSideNavigationLevel2
+                    key={group.id}
+                    subLevel={2}
+                    selected={openGroup == group.id}
+                    className={openGroup == group.id ? 'group-selected' : ''}
+                    content={
+                      <RouterLink
+                        // Button opens the children that are links to content
+                        asComponent={GroupOpenButton}
+                        onClick={() => {
+                          if (openGroup == group.id) {
+                            setOpenGroup('');
+                            return;
+                          }
+                          setOpenGroup(group.id);
+                        }}
+                      >
+                        <Heading variant="h3">{group.label}</Heading>
+                      </RouterLink>
+                    }
+                  >
+                    <MscrSideNavigationLevel3
+                      className="group"
+                      subLevel={3}
+                      selected={router.asPath.startsWith(
+                        '/' + group.id + '/crosswalks'
+                      )}
+                      content={
+                        <Link href={'/' + group.id + '/crosswalks'} passHref>
+                          <RouterLink onClick={() => setIsSearchActive(false)}>
+                            {t('workspace.crosswalks')}
+                          </RouterLink>
+                        </Link>
+                      }
+                    />
+                    <MscrSideNavigationLevel3
+                      className="group"
+                      subLevel={3}
+                      selected={router.asPath.startsWith(
+                        '/' + group.id + '/schemas'
+                      )}
+                      content={
+                        <Link href={'/' + group.id + '/schemas'} passHref>
+                          <RouterLink onClick={() => setIsSearchActive(false)}>
+                            {t('workspace.schemas')}
+                          </RouterLink>
+                        </Link>
+                      }
+                    />
+                    <MscrSideNavigationLevel3
+                      className="group"
+                      subLevel={3}
+                      selected={router.asPath.startsWith(
+                        '/' + group.id + '/settings'
+                      )}
+                      content={''}
+                    />
+                  </MscrSideNavigationLevel2>
+                ))}
+              </MscrSideNavigationLevel1>
             </MscrSideNavigation>
           </div>
         </div>
-        <FoldButtonWrapper className={'col-1 d-flex justify-content-center flex-column'} onClick={() => {
-        }}>
+        <FoldButtonWrapper
+          className={'col-1 d-flex justify-content-center flex-column'}
+        >
           <Tooltip
-            title={isSidebarMinimized ? t('click-to-expand-sidebar') : t('click-to-minimize-sidebar')}
+            title={
+              isSidebarMinimized
+                ? t('click-to-expand-sidebar')
+                : t('click-to-minimize-sidebar')
+            }
             placement="top-end"
-            className={undefined}>
+            className={undefined}
+          >
             <FoldButton
               aria-label="fold"
               onClick={(e) => {
                 sidebarFoldButtonClick();
                 e.stopPropagation();
-              }}>
+              }}
+            >
               <div></div>
               <div></div>
             </FoldButton>

--- a/mscr-ui/src/common/components/side-navigation/index.tsx
+++ b/mscr-ui/src/common/components/side-navigation/index.tsx
@@ -208,9 +208,13 @@ export default function SideNavigationPanel({ user }: { user?: MscrUser }) {
               : 'sidebar-animate-fadeout'
           }
         >
-          <PopoverNavigationMenu className='personal' buttonText='P' iconRight={<IconChevronDown />} >
+          <PopoverNavigationMenu
+            className="personal"
+            buttonText="P"
+            iconRight={<IconChevronDown />}
+          >
             <ActionMenuItem
-              key='crosswalks'
+              key="crosswalks"
               onClick={() => {
                 setOpenGroup([]);
                 setIsSearchActive(false);
@@ -221,7 +225,7 @@ export default function SideNavigationPanel({ user }: { user?: MscrUser }) {
               </Link>
             </ActionMenuItem>
             <ActionMenuItem
-              key='schemas'
+              key="schemas"
               onClick={() => {
                 setOpenGroup([]);
                 setIsSearchActive(false);
@@ -238,24 +242,39 @@ export default function SideNavigationPanel({ user }: { user?: MscrUser }) {
           <CollapsedGroupList>
             {organizations.map((group) => (
               <CollapsedGroupItem key={group.id}>
-                <GroupButton
-                  className={'collapsed'}
-                  onClick={() => {
-                    return; // Avaa popup-menu
-                  }}
+                <PopoverNavigationMenu
+                  className="group"
+                  buttonText={group.label.substring(0, 2).toUpperCase()}
+                  iconRight={<IconChevronDown />}
                 >
-                  <Heading variant="h3">
-                    {group.label.substring(0, 2).toUpperCase()}
-                  </Heading>
-                  {openGroup.includes(group.id) && <IconChevronUp />}
-                  {!openGroup.includes(group.id) && <IconChevronDown />}
-                </GroupButton>
+                  <ActionMenuItem
+                    key={`${group.id}-crosswalks`}
+                    onClick={() => {
+                      setIsSearchActive(false);
+                      setOpenGroup([group.id]);
+                    }}
+                  >
+                    <Link href={`/${group.id}/crosswalks`} passHref>
+                      {t('workspace.crosswalks')}
+                    </Link>
+                  </ActionMenuItem>
+                  <ActionMenuItem
+                    key={`${group.id}-schemas`}
+                    onClick={() => {
+                      setIsSearchActive(false);
+                      setOpenGroup([group.id]);
+                    }}
+                  >
+                    <Link href={`/${group.id}/schemas`} passHref>
+                      {t('workspace.schemas')}
+                    </Link>
+                  </ActionMenuItem>
+                </PopoverNavigationMenu>
               </CollapsedGroupItem>
             ))}
           </CollapsedGroupList>
         </CollapsedNavigationWrapper>
       </nav>
-
     );
   };
 

--- a/mscr-ui/src/common/components/side-navigation/side-navigation.styles.tsx
+++ b/mscr-ui/src/common/components/side-navigation/side-navigation.styles.tsx
@@ -149,9 +149,6 @@ export const GroupButton = styled.button`
   width: 100%;
   display: flex;
   justify-content: space-between;
-  &&.collapsed {
-    padding-right: 0;
-  }
 
   // The caret
   &&& .fi-icon {
@@ -162,19 +159,12 @@ export const GroupButton = styled.button`
     margin: auto 0;
     color: ${(props) => props.theme.suomifi.colors.depthDark1};
   }
-  &&&.collapsed .fi-icon {
-    width: 12px;
-  }
 
   && h3 {
     font-size: 16px;
     // unselected group color override
     color: ${(props) => props.theme.suomifi.colors.depthDark1};
     margin-left: ${(props) => props.theme.suomifi.spacing.s};
-  }
-  &&.collapsed h3 {
-    font-size: 14px;
-    margin-left: ${(props) => props.theme.suomifi.spacing.xxs};
   }
 
   &:hover h3, &&:hover .fi-icon {
@@ -193,10 +183,6 @@ export const GroupButton = styled.button`
     background-color: ${(props) => props.theme.suomifi.colors.depthBase};
     border-radius: 50%;
     border: solid 2px white;
-  }
-  &&.collapsed::before {
-    // adjust the dot position for collapsed menu
-    top: 40%;
   }
 `;
 
@@ -229,6 +215,7 @@ export const CollapsedNavigationWrapper = styled.nav`
 `;
 
 export const PopoverNavigationMenu = styled(ActionMenu)`
+  position: relative;
   &&.personal > button {
     height: 36px;
     width: 36px;
@@ -250,6 +237,41 @@ export const PopoverNavigationMenu = styled(ActionMenu)`
     padding: 0 12px 0 0;
     margin: 4px 0 0 4px;
   }
+  &&.group > button {
+    color: ${(props) => props.theme.suomifi.colors.depthDark1};
+    border: none;
+    cursor: pointer;
+    padding: 1px 0 0 ${(props) => props.theme.suomifi.spacing.xs};
+    width: 100%;
+    text-align: justify;
+    & > .fi-button_icon > .fi-icon {
+      position: absolute;
+      right: 0;
+      top: 38%;
+      width: 12px;
+      margin: 0;
+    }
+    &:hover {
+      background: none;
+      color: ${(props) => props.theme.suomifi.colors.highlightBase};
+    }
+    &:focus {
+      position: unset;
+    }
+    &:before {
+      // This is the little dot on the decorative line next to group names
+      content: '';
+      box-sizing: unset;
+      position: absolute;
+      top: 45%;
+      left: -5px;
+      height: 5px;
+      width: 5px;
+      background-color: ${(props) => props.theme.suomifi.colors.depthBase};
+      border-radius: 50%;
+      border: solid 2px white;
+    }
+  }
 
   // Moving the popover to the right side instead of below
   & .fi-action-menu-popover {
@@ -257,6 +279,9 @@ export const PopoverNavigationMenu = styled(ActionMenu)`
     // positioning is set as inline style, so have to use !important
     inset: unset !important;
     transform: translate(50px, -50px) !important;
+  }
+  &.group .fi-action-menu-popover {
+    transform: translate(60px, -50px) !important;
   }
   && .fi-action-menu-popover_popper-arrow {
     transform: translate(-18px, 20px) !important;
@@ -314,7 +339,7 @@ export const CollapsedGroupList = styled.ul`
 export const CollapsedGroupItem = styled.li`
   position: relative;
   margin-left: 8px;
-  padding: ${(props) => props.theme.suomifi.spacing.xxs} 0;
+  padding: ${(props) => props.theme.suomifi.spacing.xxs} 0 0 0;
   // The decorative line next to group names
   border-left: solid 1px ${(props) => props.theme.suomifi.colors.depthLight1};
 `;

--- a/mscr-ui/src/common/components/side-navigation/side-navigation.styles.tsx
+++ b/mscr-ui/src/common/components/side-navigation/side-navigation.styles.tsx
@@ -2,9 +2,10 @@ import styled from 'styled-components';
 import { Breakpoint } from 'yti-common-ui/media-query';
 import { small } from 'yti-common-ui/media-query/styled-helpers';
 import {
+  Button,
   Heading,
   SideNavigation,
-  SideNavigationItem,
+  SideNavigationItem
 } from 'suomifi-ui-components';
 
 export const SideNavigationWrapper = styled.aside<{ $breakpoint: Breakpoint; $isSidebarFolded: boolean }>`
@@ -134,11 +135,13 @@ export const PersonalNavigationWrapper = styled.div`
   margin-right: 20px;
 `;
 
-export const GroupOpenButton = styled.button`
+export const GroupOpenButton = styled(Button)`
   &&&&& {
     padding: ${(props) => props.theme.suomifi.spacing.xxs} ${(props) => props.theme.suomifi.spacing.xs};
-    // override suomifi default blue background
-    background-color: transparent;
+    // override suomifi button defaults
+    background: none;
+    text-shadow: none;
+    border: none;
   }
   && h3 {
     font-size: 16px;
@@ -152,6 +155,7 @@ export const GroupOpenButton = styled.button`
   &&::before {
     // This is the little dot on the decorative line next to group names
     content: '';
+    box-sizing: unset;
     position: absolute;
     top: 45%;
     left: -5px;

--- a/mscr-ui/src/common/components/side-navigation/side-navigation.styles.tsx
+++ b/mscr-ui/src/common/components/side-navigation/side-navigation.styles.tsx
@@ -7,17 +7,15 @@ import {
   SideNavigationItem,
 } from 'suomifi-ui-components';
 
-export const SideNavigationWrapper = styled.aside<{ $breakpoint: Breakpoint,  $isSidebarFolded: boolean }>`
+export const SideNavigationWrapper = styled.aside<{ $breakpoint: Breakpoint; $isSidebarFolded: boolean }>`
   // Width and positioning for now, need adjusting when overall layout structure is decided
   flex-grow: 1;
-  width: 100%;
   max-width: ${(props) => small(props.$breakpoint, '100%', '374px')};
   width: ${(props) => (props.$isSidebarFolded ? '50px' : '100%')};
   left: 0;
   top: 76px;
   background-color: white;
   padding-left: ${(props) => props.theme.suomifi.spacing.m};
-  padding-top: ${(props) => props.theme.suomifi.spacing.m};
   padding-bottom: ${(props) => props.theme.suomifi.spacing.m};
   margin-right: ${(props) => props.theme.suomifi.spacing.m};
   height: 100vh;
@@ -25,21 +23,27 @@ export const SideNavigationWrapper = styled.aside<{ $breakpoint: Breakpoint,  $i
   transition-timing-function: ease-in-out;
   transition-timing-function: cubic-bezier(0.42, 0, 0.58, 1);
   border-right: 3px solid ${(props) => props.theme.suomifi.colors.highlightLight3};
+
+  && .sidebar-animate-fadein {
+    animation: fadeInAnimation ease 1700ms;
+    animation-iteration-count: 1;
+    animation-fill-mode: both;
+  }
+
+  && .sidebar-animate-fadeout {
+    animation: fadeOutAnimation ease 400ms;
+    animation-iteration-count: 1;
+    animation-fill-mode: both;
+  }
 `;
 
 // Modify the style of an existing suomifi component
 export const NavigationHeading = styled(Heading)`
   // Adding &-characters increases the specificity so you can override styles
   && {
-    color: ${(props) => props.theme.suomifi.colors.depthDark2};
-    font-size: 16px;
-  }
-`;
-
-export const GroupHeading = styled(Heading)`
-  && {
-    color: ${(props) => props.theme.suomifi.colors.blackBase};
-    ${(props) => props.theme.suomifi.typography.leadTextSmallScreen};
+    text-transform: uppercase;
+    font-size: 14px;
+    font-weight: normal;
   }
 `;
 
@@ -49,64 +53,79 @@ export const MscrSideNavigation = styled(SideNavigation)`
     display: none;
   }
   height: 100vh;
-  ul {padding: 1px !important;}
 `;
 
 export const MscrSideNavigationLevel1 = styled(SideNavigationItem)`
-  // When the personal navigation subsection is active, there's a blue background and non-selected links are black
-  &.fi-side-navigation-item--child-selected {
-    div {
-      background-color: ${(props) =>
-        props.theme.suomifi.colors.highlightLight3};
-    }
-    && .personal a.fi-link--router {
-      color: ${(props) => props.theme.suomifi.colors.blackBase};
-    }
+  // A 'mask' to hide the bottom part of the gray border on the left when it's the last group in the list
+  & > ul > li:last-child::before {
+    content: "";
+    width:5px;
+    height:50%;
+    background-color:white;
+    position: absolute;
+    left:-1px;
+    bottom:-1px;
   }
 `;
 
 export const MscrSideNavigationLevel2 = styled(SideNavigationItem)`
-  && {
-    margin-right: ${(props) => props.theme.suomifi.spacing.m};
+  &&& {
+    margin: 0 ${(props) => props.theme.suomifi.spacing.s};
+    // The decorative line next to group names
+    border-left: solid 1px ${(props) => props.theme.suomifi.colors.depthLight1};
   }
-  // Remove arrow icon from group buttons
   .fi-icon {
+    // Remove arrow icon from group buttons
     display: none;
   }
-  // Group subsection background is white until a link is selected
   && .fi-side-navigation-item_sub-list {
+    padding: 0;
+    margin-top: 0;
+    // Group subsection background is white
     background-color: transparent;
   }
-  // When the group navigation subsection is active, there's a blue background and non-selected links are black
-  &.fi-side-navigation-item--child-selected {
-    background-color: ${(props) => props.theme.suomifi.colors.highlightLight3};
-    && .group a.fi-link--router {
-      color: ${(props) => props.theme.suomifi.colors.blackBase};
+
+  &.fi-side-navigation-item--child-selected, &.group-selected {
+    // Opened group name is highlight blue
+    && h3 {
+      color: ${(props) => props.theme.suomifi.colors.highlightBase};
     }
+    // Above was defined a 'mask' covering the bottom half of the decorative line on the last group in the list
+    // This is to remove the mask if the group is open
+    &:before {
+      display: none;
+    }
+  }
+
+  && h3 {
+    margin-left: ${(props) => props.theme.suomifi.spacing.xs};
   }
 `;
 
 export const MscrSideNavigationLevel3 = styled(SideNavigationItem)`
-  // Links in inactive sections are gray
+  margin: 0;
+
   &&&& a {
-    color: ${(props) => props.theme.suomifi.colors.depthDark2};
-    ${(props) => props.theme.suomifi.typography.actionElementInnerTextBold}
-  }
-  // Currently selected link is blue and has a blue left border
-  &.fi-side-navigation-item--selected {
-    border-left: solid 3px
-      ${(props) => props.theme.suomifi.colors.highlightBase};
-    &&& .fi-link--router {
-      color: ${(props) => props.theme.suomifi.colors.highlightBase};
-    }
-  }
-  &&&&& .fi-link--router {
+    font-size: 16px;
+    font-weight: 600;
+    margin: ${(props) => props.theme.suomifi.spacing.xxs} ${(props) => props.theme.suomifi.spacing.xs};
+    padding: 0 ${(props) => props.theme.suomifi.spacing.xs};
+    // Links in inactive sections are gray
+    color: ${(props) => props.theme.suomifi.colors.depthDark1};
+    // leave room for highlight border
+    border-left: solid 3px transparent;
     // override suomifi default blue background
     background-color: transparent;
     // Hovered link is blue
     &:hover {
       color: ${(props) => props.theme.suomifi.colors.highlightBase};
     }
+  }
+  &&&&&.fi-side-navigation-item--selected a {
+    // Currently selected link is blue and has a blue left border
+    color: ${(props) => props.theme.suomifi.colors.highlightBase};
+    border-left: solid 3px
+      ${(props) => props.theme.suomifi.colors.highlightBase};
   }
 `;
 
@@ -117,23 +136,30 @@ export const PersonalNavigationWrapper = styled.div`
 
 export const GroupOpenButton = styled.button`
   &&&&& {
+    padding: ${(props) => props.theme.suomifi.spacing.xxs} ${(props) => props.theme.suomifi.spacing.xs};
     // override suomifi default blue background
     background-color: transparent;
   }
-  // Hovered group name is blue
+  && h3 {
+    font-size: 16px;
+    // unselected link color override
+    color: ${(props) => props.theme.suomifi.colors.depthDark1};
+  }
   &:hover h3 {
+    // Hovered group name is highlight blue
     color: ${(props) => props.theme.suomifi.colors.highlightBase};
   }
-`;
-
-export const GroupOpenBtn = styled.div`
-  &&&&& {
-    // override suomifi default blue background
-    background-color: transparent;
-  }
-  // Hovered group name is blue
-  &:hover h3 {
-    color: ${(props) => props.theme.suomifi.colors.highlightBase};
+  &&::before {
+    // This is the little dot on the decorative line next to group names
+    content: '';
+    position: absolute;
+    top: 45%;
+    left: -5px;
+    height: 5px;
+    width: 5px;
+    background-color: ${(props) => props.theme.suomifi.colors.depthBase};
+    border-radius: 50%;
+    border: solid 2px white;
   }
 `;
 

--- a/mscr-ui/src/common/components/side-navigation/side-navigation.styles.tsx
+++ b/mscr-ui/src/common/components/side-navigation/side-navigation.styles.tsx
@@ -1,31 +1,32 @@
 import styled from 'styled-components';
 import { Breakpoint } from 'yti-common-ui/media-query';
-import { small } from 'yti-common-ui/media-query/styled-helpers';
 import {
-  Button,
   Heading,
   SideNavigation,
   SideNavigationItem
 } from 'suomifi-ui-components';
 
 export const SideNavigationWrapper = styled.aside<{ $breakpoint: Breakpoint; $isSidebarFolded: boolean }>`
-  // Width and positioning for now, need adjusting when overall layout structure is decided
-  flex: 0 0 ${(props) => (props.$isSidebarFolded ? '90px' : '250px')};
-  background-color: white;
+  flex: 0 0 ${(props) => (props.$isSidebarFolded ? '70px' : '230px')};
   padding-left: ${(props) => props.theme.suomifi.spacing.m};
+  background-color: ${(props) => props.theme.suomifi.colors.whiteBase};
 
   // Keep the white background in place when scrolling
   height: 100vh;
   position: sticky;
   top: 0;
 
-  // transition: 0.6s;
-  // transition-timing-function: ease-in-out;
-  // transition-timing-function: cubic-bezier(0.42, 0, 0.58, 1);
-   border-right: 3px solid ${(props) => props.theme.suomifi.colors.highlightLight2};
+  // Contain the expand/fold button
+  display: flex;
+  justify-content: space-between;
+
+  transition: 0.6s;
+  transition-timing-function: ease-in-out;
+  //transition-timing-function: cubic-bezier(0.42, 0, 0.58, 1);
+  border-right: 3px solid ${(props) => props.theme.suomifi.colors.highlightLight2};
 
   && .sidebar-animate-fadein {
-    animation: fadeInAnimation ease 1700ms;
+    animation: fadeInAnimation ease 1400ms;
     animation-iteration-count: 1;
     animation-fill-mode: both;
   }
@@ -47,7 +48,7 @@ export const NavigationHeading = styled(Heading)`
   }
 `;
 
-export const MscrSideNavigation = styled(SideNavigation)`
+export const MscrSideNavigation = styled(SideNavigation)<{ $isSidebarFolded: boolean }>`
   // Remove line and heading from above navigation
   .fi-side-navigation_divider, && .fi-side-navigation_heading {
     display: none;
@@ -56,11 +57,11 @@ export const MscrSideNavigation = styled(SideNavigation)`
     position: fixed;
     // Remove the height of the header banner
     height: calc(100vh - 1rem*60/18);
-    // Todo: Use the prop to determine width \${(props) => (props.$isSidebarFolded ? '90px' : '250px')}
-    width: 250px;
+    width: ${(props) => (props.$isSidebarFolded ? '57px' : '217px')};
+    transition: 0.6s;
     overflow-y: auto;
     scrollbar-width: thin;
-    scrollbar-color: ${(props) => props.theme.suomifi.colors.depthDark1};
+    scrollbar-color: ${(props) => props.theme.suomifi.colors.depthDark2} ${(props) => props.theme.suomifi.colors.highlightLight2};
   }
 `;
 
@@ -157,12 +158,19 @@ export const GroupButton = styled.button`
     margin: auto 0;
     color: ${(props) => props.theme.suomifi.colors.depthDark1};
   }
+  &&&.collapsed .fi-icon {
+    width: 12px;
+  }
 
   && h3 {
     font-size: 16px;
     // unselected group color override
     color: ${(props) => props.theme.suomifi.colors.depthDark1};
     margin-left: ${(props) => props.theme.suomifi.spacing.s};
+  }
+  &&.collapsed h3 {
+    font-size: 14px;
+    margin-left: ${(props) => props.theme.suomifi.spacing.xxs};
   }
 
   &:hover h3, &&:hover .fi-icon {
@@ -182,45 +190,84 @@ export const GroupButton = styled.button`
     border-radius: 50%;
     border: solid 2px white;
   }
+  &&.collapsed::before {
+    top: 40%;
+  }
 `;
 
-export const FoldButtonWrapper = styled.div`
-  width: 20px;
-  z-index: 0;
-  margin-left: -75px;
-`;
-
-export const FoldButton = styled.div`
-  height: 30px;
-  width: 20px;
-  display: flex;
-  flex-direction: row;
+export const ExpanderButton = styled.button`
+  border: none;
+  padding: 0 2px 0 3px;
+  background-color: ${(props) => props.theme.suomifi.colors.whiteBase};
   cursor: pointer;
-  div {
-    width: 3px;
-    height: 30px;
-    margin-left: 2px;
-    background: ${(props) => props.theme.suomifi.colors.highlightLight2};
-  }
 `;
 
-export const ExpanderButton = styled.div`
-  //height: 100%;
-  && button {
-    top: 50%;
-    height: 30px;
-    width: 1px;
-    background: none;
-    border-top: none;
-    border-bottom: none;
-    border-left: solid 3px ${(props) => props.theme.suomifi.colors.highlightLight2};
-    border-right: solid 3px ${(props) => props.theme.suomifi.colors.highlightLight2};
-  }
+export const ExpanderIcon = styled.div`
+  height: 40px;
+  width: 2px;
+  border-left: solid 3px ${(props) => props.theme.suomifi.colors.highlightLight2};
+  border-right: solid 3px ${(props) => props.theme.suomifi.colors.highlightLight2};
 `;
 
-export const CollapsedNavigationWrapper = styled.div`
+export const CollapsedNavigationWrapper = styled.nav`
+  margin-top: ${(props) => props.theme.suomifi.spacing.m};
 `;
 
 export const PersonalNavButton = styled.button`
+  height: 36px;
+  width: 36px;
+  box-sizing: border-box;
+  border-radius: 4px;
+  border: none;
+  cursor: pointer;
+  background-color: ${(props) => props.theme.suomifi.colors.highlightLight2};
+  p {
+    color: ${(props) => props.theme.suomifi.colors.highlightBase};
+    font-weight: bold;
+    font-size: 22px;
+    margin: 0;
+  }
+  svg {
+    font-size: 16px;
+  }
+  padding: 2px 0 2px 2px;
+`;
 
+export const GroupNavIcon = styled.div`
+  height: 36px;
+  width: 36px;
+  border-radius: 4px;
+  box-sizing: border-box;
+  border: none;
+  background-color: ${(props) => props.theme.suomifi.colors.depthLight2};
+  padding-left: ${(props) => props.theme.suomifi.spacing.xs};
+  p {
+    color: ${(props) => props.theme.suomifi.colors.blackBase};
+    font-weight: bold;
+    font-size: 24px;
+  }
+`;
+
+export const CollapsedGroupList = styled.ul`
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+  // Again, the 'mask' to hide the bottom part of the gray border on the left when it's the last group in the list
+  && > li:last-child::before {
+    content: "";
+    width:5px;
+    height:50%;
+    background-color:white;
+    position: absolute;
+    left:-1px;
+    bottom:-1px;
+  }
+`;
+
+export const CollapsedGroupItem = styled.li`
+  position: relative;
+  margin-left: ${(props) => props.theme.suomifi.spacing.xxs};
+  padding: ${(props) => props.theme.suomifi.spacing.xxs} 0;
+  // The decorative line next to group names
+  border-left: solid 1px ${(props) => props.theme.suomifi.colors.depthLight1};
 `;

--- a/mscr-ui/src/common/components/side-navigation/side-navigation.styles.tsx
+++ b/mscr-ui/src/common/components/side-navigation/side-navigation.styles.tsx
@@ -1,14 +1,15 @@
 import styled from 'styled-components';
 import { Breakpoint } from 'yti-common-ui/media-query';
 import {
+  ActionMenu,
   Heading,
   SideNavigation,
   SideNavigationItem
 } from 'suomifi-ui-components';
 
 export const SideNavigationWrapper = styled.aside<{ $breakpoint: Breakpoint; $isSidebarFolded: boolean }>`
-  flex: 0 0 ${(props) => (props.$isSidebarFolded ? '70px' : '230px')};
-  padding-left: ${(props) => props.theme.suomifi.spacing.m};
+  flex: 0 0 ${(props) => (props.$isSidebarFolded ? '74px' : '234px')};
+  padding-left: 16px;
   background-color: ${(props) => props.theme.suomifi.colors.whiteBase};
 
   // Keep the white background in place when scrolling
@@ -48,7 +49,7 @@ export const NavigationHeading = styled(Heading)`
   }
 `;
 
-export const MscrSideNavigation = styled(SideNavigation)<{ $isSidebarFolded: boolean }>`
+export const MscrSideNavigation = styled(SideNavigation)`
   // Remove line and heading from above navigation
   .fi-side-navigation_divider, && .fi-side-navigation_heading {
     display: none;
@@ -57,8 +58,7 @@ export const MscrSideNavigation = styled(SideNavigation)<{ $isSidebarFolded: boo
     position: fixed;
     // Remove the height of the header banner
     height: calc(100vh - 1rem*60/18);
-    width: ${(props) => (props.$isSidebarFolded ? '57px' : '217px')};
-    transition: 0.6s;
+    width: 222px;
     overflow-y: auto;
     scrollbar-width: thin;
     scrollbar-color: ${(props) => props.theme.suomifi.colors.depthDark2} ${(props) => props.theme.suomifi.colors.highlightLight2};
@@ -66,6 +66,7 @@ export const MscrSideNavigation = styled(SideNavigation)<{ $isSidebarFolded: boo
 `;
 
 export const MscrSideNavigationLevel1 = styled(SideNavigationItem)`
+  padding-right: 4px;
   // A 'mask' to hide the bottom part of the gray border on the left when it's the last group in the list
   & > ul > li:last-child::before {
     content: "";
@@ -148,6 +149,9 @@ export const GroupButton = styled.button`
   width: 100%;
   display: flex;
   justify-content: space-between;
+  &&.collapsed {
+    padding-right: 0;
+  }
 
   // The caret
   &&& .fi-icon {
@@ -191,13 +195,14 @@ export const GroupButton = styled.button`
     border: solid 2px white;
   }
   &&.collapsed::before {
+    // adjust the dot position for collapsed menu
     top: 40%;
   }
 `;
 
 export const ExpanderButton = styled.button`
   border: none;
-  padding: 0 2px 0 3px;
+  padding: 0 2px 0 1px;
   background-color: ${(props) => props.theme.suomifi.colors.whiteBase};
   cursor: pointer;
 `;
@@ -210,27 +215,68 @@ export const ExpanderIcon = styled.div`
 `;
 
 export const CollapsedNavigationWrapper = styled.nav`
-  margin-top: ${(props) => props.theme.suomifi.spacing.m};
+  box-sizing: border-box;
+  padding-top: ${(props) => props.theme.suomifi.spacing.m};
+  padding-bottom: ${(props) => props.theme.suomifi.spacing.s};
+  padding-right: 4px;
+  // Same stuff as with the expanded navigation
+  position: fixed;
+  height: calc(100vh - 1rem*60/18);
+  width: 62px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: ${(props) => props.theme.suomifi.colors.depthDark2} ${(props) => props.theme.suomifi.colors.highlightLight2};
 `;
 
-export const PersonalNavButton = styled.button`
-  height: 36px;
-  width: 36px;
-  box-sizing: border-box;
-  border-radius: 4px;
-  border: none;
-  cursor: pointer;
-  background-color: ${(props) => props.theme.suomifi.colors.highlightLight2};
-  p {
+export const PopoverNavigationMenu = styled(ActionMenu)`
+  &&.personal > button {
+    height: 36px;
+    width: 36px;
+    box-sizing: border-box;
+    border-radius: 4px;
+    border: none;
+    cursor: pointer;
+    background-color: ${(props) => props.theme.suomifi.colors.highlightLight2};
     color: ${(props) => props.theme.suomifi.colors.highlightBase};
     font-weight: bold;
-    font-size: 22px;
-    margin: 0;
+    font-size: 24px;
+    position: relative;
+    .fi-icon {
+      font-size: 16px;
+      position: absolute;
+      left: 10px;
+      top: 15px;
+    }
+    padding: 0 12px 0 0;
+    margin: 4px 0 0 4px;
   }
-  svg {
-    font-size: 16px;
+
+  // Moving the popover to the right side instead of below
+  & .fi-action-menu-popover {
+    padding: 0;
+    // positioning is set as inline style, so have to use !important
+    inset: unset !important;
+    transform: translate(50px, -50px) !important;
   }
-  padding: 2px 0 2px 2px;
+  && .fi-action-menu-popover_popper-arrow {
+    transform: translate(-18px, 20px) !important;
+    &::before, &::after {
+      transform: rotate(0.75turn);
+      inset: 0;
+    }
+    &::after {
+      left: 2px;
+      top: 1px;
+    }
+  }
+
+  & .fi-action-menu-item a {
+    text-decoration: none;
+    color: ${(props) => props.theme.suomifi.colors.blackBase};
+  }
+  & .fi-action-menu-item--selected a {
+    color: ${(props) => props.theme.suomifi.colors.whiteBase};
+  }
 `;
 
 export const GroupNavIcon = styled.div`
@@ -241,6 +287,7 @@ export const GroupNavIcon = styled.div`
   border: none;
   background-color: ${(props) => props.theme.suomifi.colors.depthLight2};
   padding-left: ${(props) => props.theme.suomifi.spacing.xs};
+  margin: 4px 0 0 4px;
   p {
     color: ${(props) => props.theme.suomifi.colors.blackBase};
     font-weight: bold;
@@ -266,7 +313,7 @@ export const CollapsedGroupList = styled.ul`
 
 export const CollapsedGroupItem = styled.li`
   position: relative;
-  margin-left: ${(props) => props.theme.suomifi.spacing.xxs};
+  margin-left: 8px;
   padding: ${(props) => props.theme.suomifi.spacing.xxs} 0;
   // The decorative line next to group names
   border-left: solid 1px ${(props) => props.theme.suomifi.colors.depthLight1};

--- a/mscr-ui/src/common/components/side-navigation/side-navigation.styles.tsx
+++ b/mscr-ui/src/common/components/side-navigation/side-navigation.styles.tsx
@@ -71,11 +71,11 @@ export const MscrSideNavigationLevel1 = styled(SideNavigationItem)`
 
 export const MscrSideNavigationLevel2 = styled(SideNavigationItem)`
   &&& {
-    margin: 0 ${(props) => props.theme.suomifi.spacing.s};
+    margin: 0 0 ${(props) => props.theme.suomifi.spacing.xxs} ${(props) => props.theme.suomifi.spacing.xs};
     // The decorative line next to group names
     border-left: solid 1px ${(props) => props.theme.suomifi.colors.depthLight1};
   }
-  .fi-icon {
+  && > span > .fi-icon {
     // Remove arrow icon from group buttons
     display: none;
   }
@@ -88,7 +88,7 @@ export const MscrSideNavigationLevel2 = styled(SideNavigationItem)`
 
   &.fi-side-navigation-item--child-selected, &.group-selected {
     // Opened group name is highlight blue
-    && h3 {
+    && h3, && .fi-icon {
       color: ${(props) => props.theme.suomifi.colors.highlightBase};
     }
     // Above was defined a 'mask' covering the bottom half of the decorative line on the last group in the list
@@ -96,10 +96,6 @@ export const MscrSideNavigationLevel2 = styled(SideNavigationItem)`
     &:before {
       display: none;
     }
-  }
-
-  && h3 {
-    margin-left: ${(props) => props.theme.suomifi.spacing.xs};
   }
 `;
 
@@ -135,23 +131,32 @@ export const PersonalNavigationWrapper = styled.div`
   margin-right: 20px;
 `;
 
-export const GroupOpenButton = styled(Button)`
-  &&&&& {
-    padding: ${(props) => props.theme.suomifi.spacing.xxs} ${(props) => props.theme.suomifi.spacing.xs};
-    // override suomifi button defaults
-    background: none;
-    text-shadow: none;
-    border: none;
-  }
-  && h3 {
-    font-size: 16px;
-    // unselected link color override
+export const GroupButton = styled.button`
+  border: none;
+  background: none;
+  cursor: pointer;
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+
+  &&& .fi-icon {
+    width: 20px;
+    height: 20px;
+    margin: auto 0;
     color: ${(props) => props.theme.suomifi.colors.depthDark1};
   }
-  &:hover h3 {
-    // Hovered group name is highlight blue
+
+  && h3 {
+    font-size: 16px;
+    // unselected group color override
+    color: ${(props) => props.theme.suomifi.colors.depthDark1};
+    margin-left: ${(props) => props.theme.suomifi.spacing.s};
+  }
+
+  &:hover h3, &&:hover .fi-icon {
     color: ${(props) => props.theme.suomifi.colors.highlightBase};
   }
+
   &&::before {
     // This is the little dot on the decorative line next to group names
     content: '';

--- a/mscr-ui/src/common/components/side-navigation/side-navigation.styles.tsx
+++ b/mscr-ui/src/common/components/side-navigation/side-navigation.styles.tsx
@@ -7,25 +7,28 @@ import {
   SideNavigationItem
 } from 'suomifi-ui-components';
 
-export const SideNavigationWrapper = styled.aside<{ $breakpoint: Breakpoint; $isSidebarFolded: boolean }>`
-  flex: 0 0 ${(props) => (props.$isSidebarFolded ? '74px' : '234px')};
+export const SideNavigationWrapper = styled.div<{ $breakpoint: Breakpoint; $isSidebarMinimized: boolean }>`
+  // Breakpoint isn't in use, but could be used for responsiveness
+
   padding-left: 16px;
   background-color: ${(props) => props.theme.suomifi.colors.whiteBase};
+  border-right: 3px solid ${(props) => props.theme.suomifi.colors.highlightLight2};
 
   // Keep the white background in place when scrolling
   height: 100vh;
   position: sticky;
   top: 0;
 
-  // Contain the expand/fold button
+  // Contain the expand/minimize button
   display: flex;
   justify-content: space-between;
 
+  // Change the width with an animation (width with padding 90px/250px)
+  flex: 0 0 ${(props) => (props.$isSidebarMinimized ? '74px' : '234px')};
   transition: 0.6s;
   transition-timing-function: ease-in-out;
-  //transition-timing-function: cubic-bezier(0.42, 0, 0.58, 1);
-  border-right: 3px solid ${(props) => props.theme.suomifi.colors.highlightLight2};
 
+  // Animations for the content switching between expanded and minimized
   && .sidebar-animate-fadein {
     animation: fadeInAnimation ease 1400ms;
     animation-iteration-count: 1;
@@ -93,7 +96,7 @@ export const MscrSideNavigationLevel2 = styled(SideNavigationItem)`
   && .fi-side-navigation-item_sub-list {
     padding: 0;
     margin-top: 0;
-    // Group subsection background is white
+    // Group subsection background override
     background-color: transparent;
   }
 
@@ -115,7 +118,7 @@ export const MscrSideNavigationLevel3 = styled(SideNavigationItem)`
 
   &&&& a {
     font-size: 16px;
-    font-weight: 600;
+    font-weight: bold;
     margin: ${(props) => props.theme.suomifi.spacing.xxs} ${(props) => props.theme.suomifi.spacing.xs};
     padding: 0 ${(props) => props.theme.suomifi.spacing.xs};
     // Links in inactive sections are gray
@@ -139,7 +142,6 @@ export const MscrSideNavigationLevel3 = styled(SideNavigationItem)`
 
 export const PersonalNavigationWrapper = styled.div`
   margin-left: 20px;
-  margin-right: 20px;
 `;
 
 export const GroupButton = styled.button`
@@ -200,7 +202,7 @@ export const ExpanderIcon = styled.div`
   border-right: solid 3px ${(props) => props.theme.suomifi.colors.highlightLight2};
 `;
 
-export const CollapsedNavigationWrapper = styled.nav`
+export const MinimizedNavigationWrapper = styled.nav`
   box-sizing: border-box;
   padding-top: ${(props) => props.theme.suomifi.spacing.m};
   padding-bottom: ${(props) => props.theme.suomifi.spacing.s};
@@ -217,6 +219,7 @@ export const CollapsedNavigationWrapper = styled.nav`
 export const PopoverNavigationMenu = styled(ActionMenu)`
   position: relative;
   &&.personal > button {
+    // Styling of the P button in minimized navigation
     height: 36px;
     width: 36px;
     box-sizing: border-box;
@@ -238,6 +241,7 @@ export const PopoverNavigationMenu = styled(ActionMenu)`
     margin: 4px 0 0 4px;
   }
   &&.group > button {
+    // Styling of the group list items in minimized navigation
     color: ${(props) => props.theme.suomifi.colors.depthDark1};
     border: none;
     cursor: pointer;
@@ -256,10 +260,11 @@ export const PopoverNavigationMenu = styled(ActionMenu)`
       color: ${(props) => props.theme.suomifi.colors.highlightBase};
     }
     &:focus {
+      // Override positioning switch
       position: unset;
     }
     &:before {
-      // This is the little dot on the decorative line next to group names
+      // This is the little dot on the decorative line next to group abbreviations
       content: '';
       box-sizing: unset;
       position: absolute;
@@ -274,9 +279,9 @@ export const PopoverNavigationMenu = styled(ActionMenu)`
   }
 
   // Moving the popover to the right side instead of below
+  // Positioning is set as inline style, so have to use !important
   & .fi-action-menu-popover {
     padding: 0;
-    // positioning is set as inline style, so have to use !important
     inset: unset !important;
     transform: translate(50px, -50px) !important;
   }
@@ -284,6 +289,7 @@ export const PopoverNavigationMenu = styled(ActionMenu)`
     transform: translate(60px, -50px) !important;
   }
   && .fi-action-menu-popover_popper-arrow {
+    // Rotate and correct position of the triangle that points to the opening button
     transform: translate(-18px, 20px) !important;
     &::before, &::after {
       transform: rotate(0.75turn);
@@ -295,6 +301,7 @@ export const PopoverNavigationMenu = styled(ActionMenu)`
     }
   }
 
+  // Override link base styles
   & .fi-action-menu-item a {
     text-decoration: none;
     color: ${(props) => props.theme.suomifi.colors.blackBase};
@@ -305,6 +312,7 @@ export const PopoverNavigationMenu = styled(ActionMenu)`
 `;
 
 export const GroupNavIcon = styled.div`
+  // Styling of the G icon in minimized menu
   height: 36px;
   width: 36px;
   border-radius: 4px;
@@ -320,7 +328,7 @@ export const GroupNavIcon = styled.div`
   }
 `;
 
-export const CollapsedGroupList = styled.ul`
+export const MinimizedGroupList = styled.ul`
   list-style-type: none;
   margin: 0;
   padding: 0;
@@ -336,7 +344,7 @@ export const CollapsedGroupList = styled.ul`
   }
 `;
 
-export const CollapsedGroupItem = styled.li`
+export const MinimizedGroupItem = styled.li`
   position: relative;
   margin-left: 8px;
   padding: ${(props) => props.theme.suomifi.spacing.xxs} 0 0 0;

--- a/mscr-ui/src/common/components/side-navigation/side-navigation.styles.tsx
+++ b/mscr-ui/src/common/components/side-navigation/side-navigation.styles.tsx
@@ -10,20 +10,19 @@ import {
 
 export const SideNavigationWrapper = styled.aside<{ $breakpoint: Breakpoint; $isSidebarFolded: boolean }>`
   // Width and positioning for now, need adjusting when overall layout structure is decided
-  flex-grow: 1;
-  max-width: ${(props) => small(props.$breakpoint, '100%', '374px')};
-  width: ${(props) => (props.$isSidebarFolded ? '50px' : '100%')};
-  left: 0;
-  top: 76px;
+  flex: 0 0 ${(props) => (props.$isSidebarFolded ? '90px' : '250px')};
   background-color: white;
   padding-left: ${(props) => props.theme.suomifi.spacing.m};
-  padding-bottom: ${(props) => props.theme.suomifi.spacing.m};
-  margin-right: ${(props) => props.theme.suomifi.spacing.m};
+
+  // Keep the white background in place when scrolling
   height: 100vh;
-  transition: 0.6s;
-  transition-timing-function: ease-in-out;
-  transition-timing-function: cubic-bezier(0.42, 0, 0.58, 1);
-  border-right: 3px solid ${(props) => props.theme.suomifi.colors.highlightLight3};
+  position: sticky;
+  top: 0;
+
+  // transition: 0.6s;
+  // transition-timing-function: ease-in-out;
+  // transition-timing-function: cubic-bezier(0.42, 0, 0.58, 1);
+   border-right: 3px solid ${(props) => props.theme.suomifi.colors.highlightLight2};
 
   && .sidebar-animate-fadein {
     animation: fadeInAnimation ease 1700ms;
@@ -49,11 +48,20 @@ export const NavigationHeading = styled(Heading)`
 `;
 
 export const MscrSideNavigation = styled(SideNavigation)`
-  // Remove line from above navigation
-  .fi-side-navigation_divider {
+  // Remove line and heading from above navigation
+  .fi-side-navigation_divider, && .fi-side-navigation_heading {
     display: none;
   }
-  height: 100vh;
+  nav {
+    position: fixed;
+    // Remove the height of the header banner
+    height: calc(100vh - 1rem*60/18);
+    // Todo: Use the prop to determine width \${(props) => (props.$isSidebarFolded ? '90px' : '250px')}
+    width: 250px;
+    overflow-y: auto;
+    scrollbar-width: thin;
+    scrollbar-color: ${(props) => props.theme.suomifi.colors.depthDark1};
+  }
 `;
 
 export const MscrSideNavigationLevel1 = styled(SideNavigationItem)`
@@ -71,7 +79,8 @@ export const MscrSideNavigationLevel1 = styled(SideNavigationItem)`
 
 export const MscrSideNavigationLevel2 = styled(SideNavigationItem)`
   &&& {
-    margin: 0 0 ${(props) => props.theme.suomifi.spacing.xxs} ${(props) => props.theme.suomifi.spacing.xs};
+    margin: 0 0 0 ${(props) => props.theme.suomifi.spacing.xs};
+    padding: 0 0 ${(props) => props.theme.suomifi.spacing.xxs} 0;
     // The decorative line next to group names
     border-left: solid 1px ${(props) => props.theme.suomifi.colors.depthLight1};
   }
@@ -139,9 +148,12 @@ export const GroupButton = styled.button`
   display: flex;
   justify-content: space-between;
 
+  // The caret
   &&& .fi-icon {
     width: 20px;
     height: 20px;
+    flex-grow: 0;
+    flex-shrink: 0;
     margin: auto 0;
     color: ${(props) => props.theme.suomifi.colors.depthDark1};
   }
@@ -190,4 +202,25 @@ export const FoldButton = styled.div`
     margin-left: 2px;
     background: ${(props) => props.theme.suomifi.colors.highlightLight2};
   }
+`;
+
+export const ExpanderButton = styled.div`
+  //height: 100%;
+  && button {
+    top: 50%;
+    height: 30px;
+    width: 1px;
+    background: none;
+    border-top: none;
+    border-bottom: none;
+    border-left: solid 3px ${(props) => props.theme.suomifi.colors.highlightLight2};
+    border-right: solid 3px ${(props) => props.theme.suomifi.colors.highlightLight2};
+  }
+`;
+
+export const CollapsedNavigationWrapper = styled.div`
+`;
+
+export const PersonalNavButton = styled.button`
+
 `;

--- a/mscr-ui/src/common/components/smart-header/index.tsx
+++ b/mscr-ui/src/common/components/smart-header/index.tsx
@@ -10,6 +10,7 @@ import {
   HeaderWrapper,
   ModalOverlay,
   ModalContent,
+  FlexItemBlock
 } from './smart-header.styles';
 import MobileNavigation from 'yti-common-ui/navigation/mobile-navigation';
 import DesktopLocaleChooser from 'yti-common-ui/locale-chooser/desktop-locale-chooser';
@@ -102,7 +103,7 @@ export default function SmartHeader({
 
   function renderHeader() {
     return (
-      <Block variant="header" role="banner" id="top-header">
+      <FlexItemBlock variant="header" role="banner" id="top-header">
         <HeaderWrapper $breakpoint={breakpoint}>
           {renderLogo()}
           {renderHeaderSearch()}
@@ -111,7 +112,7 @@ export default function SmartHeader({
           {renderDesktopAuthenticationPanel()}
         </HeaderWrapper>
         {renderUserInfo()}
-      </Block>
+      </FlexItemBlock>
     );
   }
 

--- a/mscr-ui/src/common/components/smart-header/smart-header.styles.tsx
+++ b/mscr-ui/src/common/components/smart-header/smart-header.styles.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { Breakpoint } from 'yti-common-ui/media-query';
+import { Block } from 'suomifi-ui-components';
 
 export const HeaderWrapper = styled.div<{
   $breakpoint: Breakpoint;
@@ -9,17 +10,20 @@ export const HeaderWrapper = styled.div<{
   display: flex;
   align-items: center;
   gap: 2rem;
-  height: calc(1rem*60/18);
 
   margin: auto;
   padding-right: 1rem;
   padding-left: 1rem;
-  
+
   ${(props) => `
     background-color: ${props.theme.suomifi.colors.whiteBase};
     border-bottom: 1px solid ${props.theme.suomifi.colors.depthLight1};
-    border-top: 3px solid ${props.theme.suomifi.colors.brandBase}; 
+    border-top: 3px solid ${props.theme.suomifi.colors.brandBase};
   `}
+`;
+
+export const FlexItemBlock = styled(Block)`
+  flex: 0 0 calc(1rem*60/18);
 `;
 
 export const MobileMenuButtonWrapper = styled.div`

--- a/mscr-ui/src/modules/search/search-screen/index.tsx
+++ b/mscr-ui/src/modules/search/search-screen/index.tsx
@@ -14,7 +14,6 @@ import { useCallback, useContext, useEffect } from 'react';
 import { SearchContext } from '@app/common/components/search-context-provider';
 import SearchFilterSet from 'src/modules/search/search-filter-set';
 import { useTranslation } from 'next-i18next';
-import { Grid } from '@mui/material';
 
 export default function SearchScreen() {
   const { urlState, patchUrlState } = useUrlState();
@@ -59,31 +58,23 @@ export default function SearchScreen() {
 
   return (
     <SearchContainer>
-      <Grid container justifyContent="space-between">
-        <Grid item xs={2}>
-          <FacetsWrapper>
-            {/* Groups of facets for different contexts, made with search-filter-set */}
-            <SearchFilterSet
-              title={t('search.facets.filter-by')}
-              aggregations={mscrSearchResults?.aggregations}
-            />
-          </FacetsWrapper>
-        </Grid>
-        <Grid item xs={8}>
-          <ResultsWrapper>
-            {/* Only a list of results if searching all of mscr, but later can be two lists if searching own workspace */}
-            {mscrSearchResults?.hits.hits.map((hit) => (
-              <SearchResult key={hit._id} hit={hit} />
-            ))}
-            {!foundHits && <p>{t('search.no-match')}</p>}
-          </ResultsWrapper>
-        </Grid>
-        <Grid item xs={1}>
-          <CloseButton onClick={handleClose}>
-            <IconClose />
-          </CloseButton>
-        </Grid>
-      </Grid>
+      <FacetsWrapper>
+        {/* Groups of facets for different contexts, made with search-filter-set */}
+        <SearchFilterSet
+          title={t('search.facets.filter-by')}
+          aggregations={mscrSearchResults?.aggregations}
+        />
+      </FacetsWrapper>
+      <ResultsWrapper>
+        {/* Only a list of results if searching all of mscr, but later can be two lists if searching own workspace */}
+        {mscrSearchResults?.hits.hits.map((hit) => (
+          <SearchResult key={hit._id} hit={hit} />
+        ))}
+        {!foundHits && <p>{t('search.no-match')}</p>}
+      </ResultsWrapper>
+      <CloseButton onClick={handleClose}>
+        <IconClose />
+      </CloseButton>
     </SearchContainer>
   );
 }

--- a/mscr-ui/src/modules/search/search-screen/search-screen.styles.tsx
+++ b/mscr-ui/src/modules/search/search-screen/search-screen.styles.tsx
@@ -3,24 +3,22 @@ import { Block } from 'suomifi-ui-components';
 
 export const SearchContainer = styled(Block)`
   visibility: visible;
-  height: 100%;
-  position: absolute;
+  display: flex;
+  align-items: start;
   background-color: ${(props) => props.theme.suomifi.colors.depthLight3};
   z-index: 1;
-  width: 80%;
 `;
 
 export const FacetsWrapper = styled(Block)`
-  // position: absolute;
   padding: 20px 30px 0 30px;
+  flex: 0 0 240px;
 `;
 
 export const ResultsWrapper = styled(Block)`
-  // margin-left: 200px;
+  margin-left: ${(props) => props.theme.suomifi.spacing.xxl};
+  flex: 1;
 `;
 
 export const CloseButton = styled.button`
-  //position: absolute;
-  //top: 85px;
-  //right: 5px;
+  flex: 0;
 `;

--- a/mscr-ui/src/modules/workspace/group-home/index.tsx
+++ b/mscr-ui/src/modules/workspace/group-home/index.tsx
@@ -24,6 +24,7 @@ import { getLanguageVersion } from '@app/common/utils/get-language-version';
 import { useRouter } from 'next/router';
 import { ModalVisibilityButton } from '@app/modules/form/modal-visibility-button';
 import FormModal, { ModalType } from '@app/modules/form';
+import Link from 'next/link';
 
 interface GroupHomeProps {
   user: MscrUser;
@@ -59,25 +60,28 @@ export default function GroupWorkspace({
     ? Math.ceil(data?.hits.total.value / pageSize)
     : 0;
 
+  // Todo: Refactor workspaces to share code to avoid repeated code
   const fetchedContent = useMemo(() => {
     if (data) {
       return data.hits.hits.map((result) => {
         const info = result._source;
+        const label = getLanguageVersion({
+          data: info.label,
+          lang,
+        });
         const linkUrl =
           contentType == Type.Schema
             ? router.basePath + '/schema/' + info.id
             : router.basePath + '/crosswalk/' + info.id;
+        const linkLabel = `${t('workspace.view')} ${label}`;
         return {
-          label: getLanguageVersion({
-            data: info.label,
-            lang,
-          }),
+          label: label,
           ...(contentType == Type.Schema && { namespace: info.namespace }),
           state: info.state,
           numberOfRevisions: info.numberOfRevisions.toString(),
           pid: info.handle ?? t('metadata.not-available'),
-          linkUrl: <a href={linkUrl}>{t('workspace.view')}</a>,
-        };
+          // eslint-disable-next-line jsx-a11y/anchor-is-valid
+          linkUrl: <Link href={linkUrl} passHref><a aria-label={linkLabel}>{t('workspace.view')}</a></Link>,        };
       });
     } else {
       return [];

--- a/mscr-ui/src/modules/workspace/personal-home/index.tsx
+++ b/mscr-ui/src/modules/workspace/personal-home/index.tsx
@@ -23,6 +23,7 @@ import WorkspaceTable, {
 } from '@app/modules/workspace/workspace-table';
 import { ModalVisibilityButton } from '@app/modules/form/modal-visibility-button';
 import FormModal, { ModalType } from '@app/modules/form';
+import Link from 'next/link';
 
 export default function PersonalWorkspace({
   contentType,
@@ -52,24 +53,28 @@ export default function PersonalWorkspace({
     ? Math.ceil(data?.hits.total.value / pageSize)
     : 0;
 
+  // Todo: Refactor workspaces to share code to avoid repeated code
   const fetchedContent = useMemo(() => {
     if (data) {
       return data.hits.hits.map((result) => {
         const info = result._source;
+        const label = getLanguageVersion({
+          data: info.label,
+          lang,
+        });
         const linkUrl =
           contentType == Type.Schema
             ? router.basePath + '/schema/' + info.id
             : router.basePath + '/crosswalk/' + info.id;
+        const linkLabel = `${t('workspace.view')} ${label}`;
         return {
-          label: getLanguageVersion({
-            data: info.label,
-            lang,
-          }),
+          label: label,
           ...(contentType == Type.Schema && { namespace: info.namespace }),
           state: info.state,
           numberOfRevisions: info.numberOfRevisions.toString(),
           pid: info.handle ?? t('metadata.not-available'),
-          linkUrl: <a href={linkUrl}>{t('workspace.view')}</a>,
+          // eslint-disable-next-line jsx-a11y/anchor-is-valid
+          linkUrl: <Link href={linkUrl} passHref><a aria-label={linkLabel}>{t('workspace.view')}</a></Link>,
         };
       });
     } else {

--- a/mscr-ui/src/modules/workspace/personal-home/index.tsx
+++ b/mscr-ui/src/modules/workspace/personal-home/index.tsx
@@ -108,7 +108,6 @@ export default function PersonalWorkspace({
             </TitleDescriptionWrapper>
           }
         />
-        <Separator isLarge />
         <ButtonBlock>
           {contentType == 'SCHEMA' ? (
             <>
@@ -148,7 +147,6 @@ export default function PersonalWorkspace({
             </>
           )}
         </ButtonBlock>
-        <Separator isLarge />
         {data?.hits.hits && data?.hits.hits.length < 1 ? (
           <div>
             {contentType == 'SCHEMA'

--- a/mscr-ui/src/modules/workspace/workspace.styles.tsx
+++ b/mscr-ui/src/modules/workspace/workspace.styles.tsx
@@ -4,4 +4,5 @@ import { Block } from 'suomifi-ui-components';
 export const ButtonBlock = styled(Block)`
   display: flex;
   gap: 20px;
+  margin-top: ${(props) => props.theme.suomifi.spacing.m};
 `;

--- a/mscr-ui/src/pages/401/index.tsx
+++ b/mscr-ui/src/pages/401/index.tsx
@@ -32,7 +32,6 @@ export default function UnauthorizedPage(props: unauthorizedPageProps) {
       <Layout
         user={props.user ?? undefined}
         fakeableUsers={props.fakeableUsers}
-        sideNavigationHidden={true}
       >
         <PageHead
           baseUrl="https://mscr-test.rahtiapp.fi"

--- a/mscr-ui/src/pages/crosswalk/[...pid].tsx
+++ b/mscr-ui/src/pages/crosswalk/[...pid].tsx
@@ -23,7 +23,6 @@ export default function CrosswalkPage(props: IndexPageProps) {
     <CommonContextProvider value={props}>
       <Layout
         user={props.user ?? undefined}
-        sideNavigationHidden={true}
         fakeableUsers={props.fakeableUsers}
         isActionMenu={true}
       >

--- a/mscr-ui/src/pages/mscr-style-customizations.scss
+++ b/mscr-ui/src/pages/mscr-style-customizations.scss
@@ -379,18 +379,6 @@ body {
   }
 }
 
-.sidebar-animate-fadein {
-  animation: fadeInAnimation ease 1700ms;
-  animation-iteration-count: 1;
-  animation-fill-mode: both;
-}
-
-.sidebar-animate-fadeout {
-  animation: fadeOutAnimation ease 400ms;
-  animation-iteration-count: 1;
-  animation-fill-mode: both;
-}
-
 .w-0 {
   width: 0px;
 }

--- a/mscr-ui/src/store/index.tsx
+++ b/mscr-ui/src/store/index.tsx
@@ -26,6 +26,7 @@ import { crosswalkMappingFunctionsApi } from '@app/common/components/crosswalk-f
 import { notificationsSlice } from '@app/common/components/notifications/notifications.slice';
 import { actionmenuSlice } from '@app/common/components/actionmenu/actionmenu.slice';
 import { contentViewSlice } from '@app/common/components/content-view/content-view.slice';
+import { navigationSlice } from '@app/common/components/navigation/navigation.slice';
 
 // make Context from next-redux-wrapper compatible with next-iron-session
 export type NextIronContext = Context | (Context & { req: NextApiRequest });
@@ -56,6 +57,7 @@ export function makeStore(ctx: NextIronContext) {
       [notificationsSlice.name]: notificationsSlice.reducer,
       [actionmenuSlice.name]: actionmenuSlice.reducer,
       [contentViewSlice.name]: contentViewSlice.reducer,
+      [navigationSlice.name]: navigationSlice.reducer,
     },
 
     middleware: (getDefaultMiddleware) =>


### PR DESCRIPTION
The side navigation was the first component I did styled-components for a year ago, so I used comments back then to keep track of what was happening. I decided to keep documenting the new additions now similarly, because the styling got quite involved. Had to hammer some suomi-fi-components into new shapes and forge a few of my own.

Some tangential changes:
- Clean up unused code from action menu slice and fix formatting
- Change links in workspace tables to internal (so that site doesn't reload and side menu stays minimized if), add labeling and fix table margin
- Fix pagination margin
- Fix search screen styling to play nice with the navigation