### PR TITLE
Change mscr copy to convert to mscr format

### DIFF
--- a/mscr-ui/public/locales/en/common.json
+++ b/mscr-ui/public/locales/en/common.json
@@ -29,7 +29,7 @@
     "finish-editing": "Finish editing",
     "invalidate-crosswalk": "Invalidate crosswalk",
     "invalidate-schema": "Invalidate schema",
-    "mscr-copy": "Make MSCR copy",
+    "mscr-copy": "Covert to MSCR Format",
     "publish-crosswalk": "Publish crosswalk",
     "publish-schema": "Publish schema",
     "revision": "Add new revision",

--- a/mscr-ui/public/locales/en/common.json
+++ b/mscr-ui/public/locales/en/common.json
@@ -91,7 +91,7 @@
       "crosswalk-create": "Create Crosswalk",
       "crosswalk-register": "Register Crosswalk",
       "crosswalk-revision": "Register revision",
-      "mscr-copy": "Register MSCR Copy",
+      "mscr-copy": "Convert to MSCR Format",
       "schema-register": "Register Schema",
       "schema-revision": "Register revision"
     },
@@ -109,7 +109,7 @@
       "crosswalk-mscr-copy": "Register MSCR copy of crosswalk",
       "crosswalk-register": "Register existing crosswalk",
       "crosswalk-revision": "Register revision of crosswalk",
-      "schema-mscr-copy": "Register MSCR copy of schema",
+      "schema-mscr-copy": "Convert Schema to MSCR Format",
       "schema-register": "Register schema",
       "schema-revision": "Register revision of schema"
     },
@@ -277,7 +277,7 @@
     "add-schema": "New schema added",
     "add-schema-revision": "New schema version added",
     "copy-crosswalk": "MSCR copy of crosswalk added",
-    "copy-schema": "MSCR copy of schema added",
+    "copy-schema": "Schema is converted to MSCR format",
     "crosswalk-deleted": "Crosswalk was removed",
     "crosswalk-deprecated": "Crosswalk deprecated",
     "crosswalk-invalidated": "Crosswalk invalidated",

--- a/mscr-ui/src/common/interfaces/format.interface.ts
+++ b/mscr-ui/src/common/interfaces/format.interface.ts
@@ -53,11 +53,10 @@ export const formatsAvailableForSchemaRegistration: Format[] = [
   Format.Enum,
 ];
 
+// According to current spec, MSCR Copy option only should be available to JSON, CSV and XSD Schemas
 export const formatsAvailableForMscrCopy: Format[] = [
   Format.Csv,
   Format.Jsonschema,
-  Format.Mscr,
-  Format.Shacl,
   Format.Xsd
 ];
 

--- a/mscr-ui/src/common/utils/has-permission.tsx
+++ b/mscr-ui/src/common/utils/has-permission.tsx
@@ -77,9 +77,7 @@ export default function HasPermission({ action, owner }: hasPermissionProps) {
 }
 
 export function checkPermission({ user, action, owner }: checkPermissionProps) {
-  if (action == 'MAKE_MSCR_COPY') {
-    return true;
-  } else if (action == 'EDIT_CONTENT') {
+  if (action == 'EDIT_CONTENT'||'MAKE_MSCR_COPY') {
     if (owner?.includes(user.id)) {
       //user is the owner, Check for personal Contents
       return true;

--- a/mscr-ui/src/modules/schema-view/index.tsx
+++ b/mscr-ui/src/modules/schema-view/index.tsx
@@ -69,7 +69,7 @@ export default function SchemaView({ schemaId }: { schemaId: string }) {
     isEditContentActive &&
     hasEditPermission &&
     schemaData?.format === Format.Mscr;
-  const hasCopyPermission = HasPermission({ action: 'MAKE_MSCR_COPY' });
+  const hasCopyPermission = HasPermission({ action: 'MAKE_MSCR_COPY', owner: schemaData?.owner});
   const router = useRouter(); // Force refresh the page
   const isMscrCopyAvailable =
     hasCopyPermission &&


### PR DESCRIPTION
Added Changes:

1. Changed MSCR copy option to convert to MSCR format.
2. Make convert to mscr option only available for CSV,JSON and XSD schemas