### PR TITLE
CSCFC4EMSCR-612 Hide create content buttons from group members

### DIFF
--- a/mscr-ui/src/common/utils/has-permission.tsx
+++ b/mscr-ui/src/common/utils/has-permission.tsx
@@ -11,16 +11,15 @@ import { Roles } from '../interfaces/format.interface';
 
 // Need to specify the actions permitted for each type of user
 const actions = [
-  // 'CREATE_SCHEMA',
   // 'EDIT_SCHEMA',
   // 'EDIT_SCHEMA_METADATA',
   // 'EDIT_SCHEMA_FILES',
   // 'DELETE_SCHEMA',
-  // 'CREATE_CROSSWALK',
   // 'EDIT_CROSSWALK_MAPPINGS',
   // 'EDIT_CROSSWALK_METADATA',
   // 'EDIT_CROSSWALK_FILES',
   // 'DELETE_CROSSWALK',
+  'CREATE_CONTENT',
   'EDIT_CONTENT',
   'MAKE_MSCR_COPY',
 ] as const;
@@ -77,7 +76,7 @@ export default function HasPermission({ action, owner }: hasPermissionProps) {
 }
 
 export function checkPermission({ user, action, owner }: checkPermissionProps) {
-  if (action == 'EDIT_CONTENT'||'MAKE_MSCR_COPY') {
+  if (action == 'EDIT_CONTENT' || action == 'CREATE_CONTENT' || action == 'MAKE_MSCR_COPY') {
     if (owner?.includes(user.id)) {
       //user is the owner, Check for personal Contents
       return true;

--- a/mscr-ui/src/modules/workspace/group-home/index.tsx
+++ b/mscr-ui/src/modules/workspace/group-home/index.tsx
@@ -23,6 +23,7 @@ import FormModal, { ModalType } from '@app/modules/form';
 import Link from 'next/link';
 import { SpinnerWrapper } from '@app/modules/crosswalk-view/crosswalk-view.styles';
 import SpinnerOverlay from '@app/common/components/spinner-overlay';
+import HasPermission from '@app/common/utils/has-permission';
 
 interface GroupHomeProps {
   user: MscrUser;
@@ -34,6 +35,10 @@ export default function GroupWorkspace({
   pid,
   contentType,
 }: GroupHomeProps) {
+  const hasCreatePermission = HasPermission({
+    action: 'CREATE_CONTENT',
+    owner: [pid],
+  });
   const { t } = useTranslation('common');
   const router = useRouter();
   const lang = router.locale ?? '';
@@ -122,52 +127,54 @@ export default function GroupWorkspace({
             </TitleDescriptionWrapper>
           }
         />
-        <Separator isLarge />
-        <div>
-          <ButtonBlock>
-            {contentType == 'SCHEMA' ? (
-              <>
-                <ModalVisibilityButton
-                  setVisible={setRegisterSchemaModalVisible}
-                  label={t('content-form.button.schema-register')}
-                />
-                <FormModal
-                  modalType={ModalType.RegisterNewFull}
-                  contentType={Type.Schema}
-                  visible={registerSchemaModalVisible}
-                  setVisible={setRegisterSchemaModalVisible}
-                  organizationPid={pid}
-                />
-              </>
-            ) : (
-              <>
-                <ModalVisibilityButton
-                  setVisible={setRegisterCrosswalkModalVisible}
-                  label={t('content-form.button.crosswalk-register')}
-                />
-                <FormModal
-                  modalType={ModalType.RegisterNewFull}
-                  contentType={Type.Crosswalk}
-                  visible={registerCrosswalkModalVisible}
-                  setVisible={setRegisterCrosswalkModalVisible}
-                  organizationPid={pid}
-                />
-                <ModalVisibilityButton
-                  setVisible={setCreateCrosswalkModalVisible}
-                  label={t('content-form.button.crosswalk-create')}
-                />
-                <FormModal
-                  modalType={ModalType.RegisterNewMscr}
-                  contentType={Type.Crosswalk}
-                  visible={createCrosswalkModalVisible}
-                  setVisible={setCreateCrosswalkModalVisible}
-                  organizationPid={pid}
-                />
-              </>
-            )}
-          </ButtonBlock>
-        </div>
-        <Separator isLarge />
+        {hasCreatePermission &&
+          <div>
+            <Separator isLarge />
+            <ButtonBlock>
+              {contentType == 'SCHEMA' ? (
+                <>
+                  <ModalVisibilityButton
+                    setVisible={setRegisterSchemaModalVisible}
+                    label={t('content-form.button.schema-register')}
+                  />
+                  <FormModal
+                    modalType={ModalType.RegisterNewFull}
+                    contentType={Type.Schema}
+                    visible={registerSchemaModalVisible}
+                    setVisible={setRegisterSchemaModalVisible}
+                    organizationPid={pid}
+                  />
+                </>
+              ) : (
+                <>
+                  <ModalVisibilityButton
+                    setVisible={setRegisterCrosswalkModalVisible}
+                    label={t('content-form.button.crosswalk-register')}
+                  />
+                  <FormModal
+                    modalType={ModalType.RegisterNewFull}
+                    contentType={Type.Crosswalk}
+                    visible={registerCrosswalkModalVisible}
+                    setVisible={setRegisterCrosswalkModalVisible}
+                    organizationPid={pid}
+                  />
+                  <ModalVisibilityButton
+                    setVisible={setCreateCrosswalkModalVisible}
+                    label={t('content-form.button.crosswalk-create')}
+                  />
+                  <FormModal
+                    modalType={ModalType.RegisterNewMscr}
+                    contentType={Type.Crosswalk}
+                    visible={createCrosswalkModalVisible}
+                    setVisible={setCreateCrosswalkModalVisible}
+                    organizationPid={pid}
+                  />
+                </>
+              )}
+            </ButtonBlock>
+            <Separator isLarge />
+          </div>
+        }
         {data?.hits.hits && data?.hits.hits.length < 1 ? (
           <div>
             {contentType == 'SCHEMA'


### PR DESCRIPTION
Buttons for registering/creating content in a group workspace are now only visible to group admins and editors, not members